### PR TITLE
Refactoring and Ice Arrow fix

### DIFF
--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/AncientArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/AncientArrowEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.projectile.AbstractArrowEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.IPacket;
 import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.network.NetworkHooks;
@@ -25,10 +26,6 @@ public class AncientArrowEntity extends AbstractArrowEntity
         this.setBaseDamage(this.getBaseDamage() + 30.0F);
     }
 
-    public AncientArrowEntity(World worldIn, double x, double y, double z) {
-        super(EntityTypeInit.ANCIENT_ARROW.get(), x, y, z, worldIn);
-    }
-
     @Override
     protected ItemStack getPickupItem() {
         return new ItemStack(ItemInit.ANCIENT_ARROW.get());
@@ -42,14 +39,18 @@ public class AncientArrowEntity extends AbstractArrowEntity
     @Override
     protected void doPostHurtEffects(LivingEntity entity) {
         super.doPostHurtEffects(entity);
-        if(entity.canChangeDimensions()){
-        	BlockPos currentPos = entity.blockPosition();
-            entity.level.playSound(null, currentPos.getX(), currentPos.getY(), currentPos.getZ(), SoundInit.ARROW_HIT_ANCIENT.get(), SoundCategory.PLAYERS, 1f, 1f);
-            //entity.setHealth(0);
-        }else {
-        	BlockPos currentPos = entity.blockPosition();
-            entity.level.playSound(null, currentPos.getX(), currentPos.getY(), currentPos.getZ(), SoundInit.ARROW_HIT_ANCIENT.get(), SoundCategory.PLAYERS, 1f, 1f);
-            //entity.setHealth(entity.getHealth()-45);
-        }
+        playSoundAtBlockPosition(entity, SoundInit.ARROW_HIT_ANCIENT.get());
+
+        /* This method contained the following if-statement
+            if (entity.canChangeDimensions())
+                entity.setHealth(0);
+            else
+                entity.setHealth(entity.getHealth() - 45);
+         */
+    }
+
+    private void playSoundAtBlockPosition(LivingEntity entity, SoundEvent sound) {
+        BlockPos currentPos = entity.blockPosition();
+        entity.level.playSound(null, currentPos.getX(), currentPos.getY(), currentPos.getZ(), sound, SoundCategory.PLAYERS, 1f, 1f);
     }
 }

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/FireArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/FireArrowEntity.java
@@ -13,7 +13,9 @@ import net.minecraft.entity.projectile.AbstractArrowEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.IPacket;
 import net.minecraft.particles.ParticleTypes;
+import net.minecraft.util.Direction;
 import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.EntityRayTraceResult;
@@ -31,12 +33,7 @@ public class FireArrowEntity extends AbstractArrowEntity
 	{
 		super(EntityTypeInit.FIRE_ARROW.get(), shooter, worldIn);
 	}
-	
-	public FireArrowEntity(World worldIn, double x, double y, double z)
-	{
-		super(EntityTypeInit.FIRE_ARROW.get(), x, y, z, worldIn);
-	}
-	
+
 	public FireArrowEntity(EntityType<? extends FireArrowEntity> type, World worldIn, LivingEntity shooter)
 	{
 		super(type, shooter, worldIn);
@@ -71,24 +68,21 @@ public class FireArrowEntity extends AbstractArrowEntity
 	{
 		Entity entity = rayTraceResult.getEntity();
 		
-		if (entity.isAlive())
-		{
+		if (entity.isAlive()) {
 			entity.setSecondsOnFire(6);
-		}
-		
-		if (TagInit.RESISTANT_TO_FIRE.contains(entity.getType()))
-		{
-			setBaseDamage(getBaseDamage() / 2f);
-		}
-		
-		if (TagInit.WEAK_TO_FIRE.contains(entity.getType()))
-		{
-			setBaseDamage(getBaseDamage() * 2f);
+			applyResistanceAndWeakness(entity);
 		}
 		
 		super.onHitEntity(rayTraceResult);
 	}
-	
+
+	private void applyResistanceAndWeakness(Entity entity) {
+		if (TagInit.RESISTANT_TO_FIRE.contains(entity.getType()))
+			setBaseDamage(getBaseDamage() / 2f);
+		else if (TagInit.WEAK_TO_FIRE.contains(entity.getType()))
+			setBaseDamage(getBaseDamage() * 2f);
+	}
+
 	@Override
 	protected void doPostHurtEffects(LivingEntity entity)
 	{
@@ -100,56 +94,64 @@ public class FireArrowEntity extends AbstractArrowEntity
 	public void tick()
 	{
 		super.tick();
-		
+
+		addFireParticlesToFlighPath();
+		burnGroundOnImpact();
+		extinguishInWater();
+	}
+
+	private void burnGroundOnImpact() {
+		if (this.inGround)
+		{
+			if (!this.isInWaterOrRain())
+			{
+				if (level.isEmptyBlock(this.blockPosition()))
+					level.setBlock(this.blockPosition(), Blocks.FIRE.defaultBlockState(), 11);
+
+				playSoundAtBlockPosition(SoundInit.ARROW_HIT_FIRE.get());
+
+				this.remove();
+
+				setHorizontallyAdjacentBlocksAblaze();
+			}
+		}
+	}
+
+	private void addFireParticlesToFlighPath() {
 		if (!this.isInWaterOrRain() && !this.inGround)
 		{
 			this.level.addParticle(ParticleTypes.FLAME, this.getX(), this.getY(), this.getZ(), 0.0D, 0.0D, 0.0D);
 		}
-		
-		if (this.inGround)
-		{
-			if (!this.isInWaterOrRain() || !this.isInWater())
-			{
-				if (level.isEmptyBlock(this.blockPosition()))
-					level.setBlock(this.blockPosition(), Blocks.FIRE.defaultBlockState(), 11);
-				
-				BlockPos currentPos = this.blockPosition();
-				this.level.playSound(null, currentPos.getX(), currentPos.getY(), currentPos.getZ(), SoundInit.ARROW_HIT_FIRE.get(), SoundCategory.PLAYERS, 1f,
-						1f);
-				
-				this.remove();
-			}
-			if (!this.isInWaterOrRain() || !this.isInWater())
-			{
-				if (level.isEmptyBlock(this.blockPosition().west()))
-					level.setBlock(this.blockPosition().west(), Blocks.FIRE.defaultBlockState(), 11);
-				
-			}
-			if (!this.isInWaterOrRain() || !this.isInWater())
-			{
-				if (level.isEmptyBlock(this.blockPosition().east()))
-					level.setBlock(this.blockPosition().east(), Blocks.FIRE.defaultBlockState(), 11);
-				
-			}
-			if (!this.isInWaterOrRain() || !this.isInWater())
-			{
-				if (level.isEmptyBlock(this.blockPosition().north()))
-					level.setBlock(this.blockPosition().north(), Blocks.FIRE.defaultBlockState(), 11);
-				
-			}
-			if (!this.isInWaterOrRain() || !this.isInWater())
-			{
-				if (level.isEmptyBlock(this.blockPosition().south()))
-					level.setBlock(this.blockPosition().south(), Blocks.FIRE.defaultBlockState(), 11);
-				
-			}
-		}
-		
+	}
+
+	private void extinguishInWater() {
+		// TODO shouldn't this include rain?
 		if (this.isInWater())
 		{
-			BlockPos currentPos = this.blockPosition();
-			this.level.playSound(null, currentPos.getX(), currentPos.getY(), currentPos.getZ(), SoundEvents.FIRE_EXTINGUISH, SoundCategory.PLAYERS, 1f, 1f);
+			playSoundAtBlockPosition(SoundEvents.FIRE_EXTINGUISH);
 			this.remove();
 		}
+	}
+
+	private void playSoundAtBlockPosition(SoundEvent soundEvent) {
+		BlockPos currentPos = this.blockPosition();
+		this.level.playSound(null, currentPos.getX(), currentPos.getY(), currentPos.getZ(), soundEvent, SoundCategory.PLAYERS, 1f,
+				1f);
+	}
+
+	private void setHorizontallyAdjacentBlocksAblaze()
+	{
+		if (isEmptyBlock(Direction.WEST))
+			level.setBlock(this.blockPosition().west(), Blocks.FIRE.defaultBlockState(), 11);
+		if (isEmptyBlock(Direction.EAST))
+			level.setBlock(this.blockPosition().east(), Blocks.FIRE.defaultBlockState(), 11);
+		if (isEmptyBlock(Direction.NORTH))
+			level.setBlock(this.blockPosition().north(), Blocks.FIRE.defaultBlockState(), 11);
+		if (isEmptyBlock(Direction.SOUTH))
+			level.setBlock(this.blockPosition().south(), Blocks.FIRE.defaultBlockState(), 11);
+	}
+
+	private boolean isEmptyBlock(Direction dir) {
+		return level.isEmptyBlock(this.blockPosition().relative(dir));
 	}
 }

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/FireArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/FireArrowEntity.java
@@ -95,7 +95,7 @@ public class FireArrowEntity extends AbstractArrowEntity
 	{
 		super.tick();
 
-		addFireParticlesToFlighPath();
+		addFireParticlesToFlightPath();
 		burnGroundOnImpact();
 		extinguishInWater();
 	}
@@ -117,7 +117,7 @@ public class FireArrowEntity extends AbstractArrowEntity
 		}
 	}
 
-	private void addFireParticlesToFlighPath() {
+	private void addFireParticlesToFlightPath() {
 		if (!this.isInWaterOrRain() && !this.inGround)
 		{
 			this.level.addParticle(ParticleTypes.FLAME, this.getX(), this.getY(), this.getZ(), 0.0D, 0.0D, 0.0D);

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/IceArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/IceArrowEntity.java
@@ -45,12 +45,7 @@ public class IceArrowEntity extends AbstractArrowEntity
 	{
 		super(EntityTypeInit.ICE_ARROW.get(), shooter, worldIn);
 	}
-	
-	public IceArrowEntity(World worldIn, double x, double y, double z)
-	{
-		super(EntityTypeInit.ICE_ARROW.get(), x, y, z, worldIn);
-	}
-	
+
 	public IceArrowEntity(EntityType<? extends IceArrowEntity> type, World worldIn, LivingEntity shooter)
 	{
 		super(type, shooter, worldIn);
@@ -83,175 +78,14 @@ public class IceArrowEntity extends AbstractArrowEntity
 	@Override
 	public void tick()
 	{
+		super.tick();
+
 		if (!inGround)
 		{
 			level.addParticle(ParticleTypes.ITEM_SNOWBALL, getX(), getY(), getZ(), 0.0D, 0.0D, 0.0D);
 			level.addParticle(ParticleTypes.SPIT, getX(), getY(), getZ(), 0.0D, 0.0D, 0.0D);
 		}
 		
-		if (!leftOwner)
-		{
-			leftOwner = checkLeftOwner();
-		}
-		
-		if (!level.isClientSide)
-		{
-			setSharedFlag(6, isGlowing());
-		}
-		
-		baseTick();
-		
-		boolean flag = isNoPhysics();
-		Vector3d vector3d = getDeltaMovement();
-		if (xRotO == 0.0F && yRotO == 0.0F)
-		{
-			float f = MathHelper.sqrt(getHorizontalDistanceSqr(vector3d));
-			yRot = (float) (MathHelper.atan2(vector3d.x, vector3d.z) * (double) (180F / (float) Math.PI));
-			xRot = (float) (MathHelper.atan2(vector3d.y, (double) f) * (double) (180F / (float) Math.PI));
-			yRotO = yRot;
-			xRotO = xRot;
-		}
-		
-		BlockPos blockpos = blockPosition();
-		BlockState blockstate = level.getBlockState(blockpos);
-		
-		if (!blockstate.getBlock().isAir(blockstate, level, blockpos) && !flag)
-		{
-			VoxelShape voxelshape = blockstate.getCollisionShape(level, blockpos);
-			if (!voxelshape.isEmpty())
-			{
-				Vector3d vector3d1 = position();
-				
-				for (AxisAlignedBB axisalignedbb : voxelshape.toAabbs())
-				{
-					if (axisalignedbb.move(blockpos).contains(vector3d1))
-					{
-						inGround = true;
-						break;
-					}
-				}
-			}
-		}
-		
-		if (shakeTime > 0)
-		{
-			--shakeTime;
-		}
-		
-		if (isInWaterOrRain())
-		{
-			clearFire();
-		}
-		
-		if (inGround && !flag)
-		{
-			if (lastState != blockstate && shouldFall())
-			{
-				startFalling();
-			}
-			else if (!level.isClientSide)
-			{
-				tickDespawn();
-			}
-			
-			++inGroundTime;
-		}
-		else
-		{
-			inGroundTime = 0;
-			Vector3d vector3d2 = position();
-			Vector3d vector3d3 = vector3d2.add(vector3d);
-			RayTraceResult raytraceresult = level
-					.clip(new RayTraceContext(vector3d2, vector3d3, RayTraceContext.BlockMode.COLLIDER, RayTraceContext.FluidMode.ANY, this));
-			if (raytraceresult.getType() != RayTraceResult.Type.MISS)
-			{
-				vector3d3 = raytraceresult.getLocation();
-			}
-			
-			while (isAlive())
-			{
-				EntityRayTraceResult entityraytraceresult = findHitEntity(vector3d2, vector3d3);
-				if (entityraytraceresult != null)
-				{
-					raytraceresult = entityraytraceresult;
-				}
-				
-				if (raytraceresult != null && raytraceresult.getType() == RayTraceResult.Type.ENTITY)
-				{
-					Entity entity = ((EntityRayTraceResult) raytraceresult).getEntity();
-					Entity entity1 = getOwner();
-					if (entity instanceof PlayerEntity && entity1 instanceof PlayerEntity && !((PlayerEntity) entity1).canHarmPlayer((PlayerEntity) entity))
-					{
-						raytraceresult = null;
-						entityraytraceresult = null;
-					}
-				}
-				
-				if (raytraceresult != null && raytraceresult.getType() != RayTraceResult.Type.MISS && !flag
-						&& !net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, raytraceresult))
-				{
-					onHit(raytraceresult);
-					hasImpulse = true;
-				}
-				
-				if (entityraytraceresult == null || getPierceLevel() <= 0)
-				{
-					break;
-				}
-				
-				raytraceresult = null;
-			}
-			
-			vector3d = getDeltaMovement();
-			double d3 = vector3d.x;
-			double d4 = vector3d.y;
-			double d0 = vector3d.z;
-			if (isCritArrow())
-			{
-				for (int i = 0; i < 4; ++i)
-				{
-					level.addParticle(ParticleTypes.CRIT, getX() + d3 * (double) i / 4.0D, getY() + d4 * (double) i / 4.0D, getZ() + d0 * (double) i / 4.0D,
-							-d3, -d4 + 0.2D, -d0);
-				}
-			}
-			
-			double d5 = getX() + d3;
-			double d1 = getY() + d4;
-			double d2 = getZ() + d0;
-			float f1 = MathHelper.sqrt(getHorizontalDistanceSqr(vector3d));
-			if (flag)
-			{
-				yRot = (float) (MathHelper.atan2(-d3, -d0) * (double) (180F / (float) Math.PI));
-			}
-			else
-			{
-				yRot = (float) (MathHelper.atan2(d3, d0) * (double) (180F / (float) Math.PI));
-			}
-			
-			xRot = (float) (MathHelper.atan2(d4, (double) f1) * (double) (180F / (float) Math.PI));
-			xRot = lerpRotation(xRotO, xRot);
-			yRot = lerpRotation(yRotO, yRot);
-			float f2 = 0.99F;
-			if (isInWater())
-			{
-				for (int j = 0; j < 4; ++j)
-				{
-					level.addParticle(ParticleTypes.BUBBLE, d5 - d3 * 0.25D, d1 - d4 * 0.25D, d2 - d0 * 0.25D, d3, d4, d0);
-				}
-				
-				f2 = getWaterInertia();
-			}
-			
-			setDeltaMovement(vector3d.scale((double) f2));
-			if (!isNoGravity() && !flag)
-			{
-				Vector3d vector3d4 = getDeltaMovement();
-				setDeltaMovement(vector3d4.x, vector3d4.y - (double) 0.05F, vector3d4.z);
-			}
-			
-			setPos(d5, d1, d2);
-			checkInsideBlocks();
-		}
 	}
 	
 	@Override
@@ -324,35 +158,4 @@ public class IceArrowEntity extends AbstractArrowEntity
 		entity.addEffect(new EffectInstance(Effects.MOVEMENT_SLOWDOWN, 70, 255));
 	}
 	
-	private boolean shouldFall()
-	{
-		return this.inGround && this.level.noCollision((new AxisAlignedBB(this.position(), this.position())).inflate(0.06D));
-	}
-	
-	private void startFalling()
-	{
-		this.inGround = false;
-		Vector3d vector3d = this.getDeltaMovement();
-		this.setDeltaMovement(vector3d.multiply((double) (this.random.nextFloat() * 0.2F), (double) (this.random.nextFloat() * 0.2F),
-				(double) (this.random.nextFloat() * 0.2F)));
-		this.life = 0;
-	}
-	
-	private boolean checkLeftOwner()
-	{
-		Entity entity = this.getOwner();
-		if (entity != null)
-		{
-			for (Entity entity1 : this.level.getEntities(this, this.getBoundingBox().expandTowards(this.getDeltaMovement()).inflate(1.0D),
-					entity2 -> !entity2.isSpectator() && entity2.isPickable()))
-			{
-				if (entity1.getRootVehicle() == entity.getRootVehicle())
-				{
-					return false;
-				}
-			}
-		}
-		
-		return true;
-	}
 }

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/MagicFireArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/MagicFireArrowEntity.java
@@ -33,11 +33,6 @@ public class MagicFireArrowEntity extends FireArrowEntity
 		super(EntityTypeInit.MAGIC_FIRE_ARROW.get(), worldIn, shooter);
 	}
 	
-	public MagicFireArrowEntity(World worldIn, double x, double y, double z)
-	{
-		super(EntityTypeInit.MAGIC_FIRE_ARROW.get(), worldIn, x, y, z);
-	}
-	
 	@Override
 	public void onAddedToWorld()
 	{

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/MagicIceArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/MagicIceArrowEntity.java
@@ -23,12 +23,7 @@ public class MagicIceArrowEntity extends IceArrowEntity
 	{
 		super(EntityTypeInit.MAGIC_ICE_ARROW.get(), worldIn, shooter);
 	}
-	
-	public MagicIceArrowEntity(World worldIn, double x, double y, double z)
-	{
-		super(EntityTypeInit.MAGIC_ICE_ARROW.get(), worldIn, x, y, z);
-	}
-	
+
 	@Override
 	public void onAddedToWorld()
 	{

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/MagicLightArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/MagicLightArrowEntity.java
@@ -26,12 +26,7 @@ public class MagicLightArrowEntity extends AbstractArrowEntity
 	{
 		super(EntityTypeInit.MAGIC_LIGHT_ARROW.get(), shooter, worldIn);
 	}
-	
-	public MagicLightArrowEntity(World worldIn, double x, double y, double z)
-	{
-		super(EntityTypeInit.MAGIC_LIGHT_ARROW.get(), x, y, z, worldIn);
-	}
-	
+
 	@Override
 	public void onAddedToWorld()
 	{
@@ -55,17 +50,9 @@ public class MagicLightArrowEntity extends AbstractArrowEntity
 	protected void onHitEntity(EntityRayTraceResult rayTraceResult)
 	{
 		Entity entity = rayTraceResult.getEntity();
-		
-		if (TagInit.WEAK_TO_LIGHT.contains(entity.getType()))
-		{
-			setBaseDamage(getBaseDamage() * 2);
-		}
-		
-		if (TagInit.RESISTANT_TO_LIGHT.contains(entity.getType()))
-		{
-			setBaseDamage(getBaseDamage() / 2);
-		}
-		
+
+		applyResistanceAndWeakness(entity);
+
 		super.onHitEntity(rayTraceResult);
 		
 		// There is a small time frame after an entity is hurt that gives
@@ -73,5 +60,12 @@ public class MagicLightArrowEntity extends AbstractArrowEntity
 		// an arrow. To deal damage 2 times in a row, we have to reset it.
 		entity.invulnerableTime = 0;
 		entity.hurt(DamageSource.MAGIC, 5.0F);
+	}
+
+	private void applyResistanceAndWeakness(Entity entity) {
+		if (TagInit.WEAK_TO_LIGHT.contains(entity.getType()))
+			setBaseDamage(getBaseDamage() * 2);
+		if (TagInit.RESISTANT_TO_LIGHT.contains(entity.getType()))
+			setBaseDamage(getBaseDamage() / 2);
 	}
 }

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/PoisonArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/PoisonArrowEntity.java
@@ -2,6 +2,7 @@ package com.superworldsun.superslegend.entities.projectiles.arrows;
 
 import com.superworldsun.superslegend.registries.ItemInit;
 import com.superworldsun.superslegend.registries.EntityTypeInit;
+import com.superworldsun.superslegend.util.Functions;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.AbstractArrowEntity;
@@ -36,14 +37,15 @@ public class PoisonArrowEntity extends AbstractArrowEntity {
     /**
      * Called to update the entity's position/logic.
      */
+    @Override
     public void tick() {
         super.tick();
 
         if (!level.isClientSide() && !this.inGround || !level.isClientSide() && !this.isInWaterOrRain() || !level.isClientSide() && !this.isInWater()) {
-            this.level.addParticle(ParticleTypes.COMPOSTER, this.getX(), this.getY(), this.getZ(), 0.0D, 0.0D,
-                    0.0D);
-            this.level.addParticle(ParticleTypes.COMPOSTER, this.getX(), this.getY(), this.getZ(), 0.0D, 0.0D,
-                    0.0D);
+            Functions.repeat(2, () -> {
+                this.level.addParticle(ParticleTypes.COMPOSTER, this.getX(), this.getY(), this.getZ(), 0.0D, 0.0D,
+                        0.0D);
+            });
         }
     }
 
@@ -54,7 +56,6 @@ public class PoisonArrowEntity extends AbstractArrowEntity {
 
     @Override
     protected void doPostHurtEffects(LivingEntity living) {
-        BlockPos currentPos = this.blockPosition();
         living.addEffect(new EffectInstance(Effects.POISON, 1200, 1));
         super.doPostHurtEffects(living);
     }

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/ShockArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/ShockArrowEntity.java
@@ -27,10 +27,6 @@ public class ShockArrowEntity extends AbstractArrowEntity {
         this.setBaseDamage(this.getBaseDamage() + 2.0F);
     }
 
-    public ShockArrowEntity(World worldIn, double x, double y, double z) {
-        super(EntityTypeInit.SHOCK_ARROW.get(), x, y, z, worldIn);
-    }
-
     @Override
     protected ItemStack getPickupItem() {
         return new ItemStack(ItemInit.SHOCK_ARROW.get());

--- a/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/SilverArrowEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/entities/projectiles/arrows/SilverArrowEntity.java
@@ -37,9 +37,7 @@ public class SilverArrowEntity extends AbstractArrowEntity
     @Override
     protected void doPostHurtEffects(LivingEntity living) {
         if(living instanceof WitherSkeletonEntity)
-        {
-            this.setBaseDamage(this.getBaseDamage() *100);
-        }
+            this.setBaseDamage(this.getBaseDamage() * 100);
         super.doPostHurtEffects(living);
     }
 

--- a/src/main/java/com/superworldsun/superslegend/util/Functions.java
+++ b/src/main/java/com/superworldsun/superslegend/util/Functions.java
@@ -1,0 +1,14 @@
+package com.superworldsun.superslegend.util;
+
+public class Functions {
+    private Functions() {}
+
+
+    public static void repeat(int times, Runnable action) {
+        while (times > 0) {
+            action.run();
+            times--;
+        }
+    }
+
+}


### PR DESCRIPTION
- Refactored the FireArrowEntity. I changed the check if(!this.isInWaterOrRain() || !this.isInWater()) since it would resulting to setting fire to the ground eve n if it's raining, because the later half would stil be true.
- Minor refactoring on the ancient arrow.
- Minor refactoring on the bomb arrow.
- Refactoring of the Ice Arrow - Removed the arrow logic and replaced it with super.tick()
- Ice Arrow - Moved chaning water and laver to ice and obsidian into tick, because it doesn't detect on block hit
- Minor changes
