### PR TITLE
Modified Hover Boots (Cleaner Commits)

### DIFF
--- a/src/main/java/com/superworldsun/superslegend/interfaces/IHoveringEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/interfaces/IHoveringEntity.java
@@ -11,4 +11,8 @@ public interface IHoveringEntity
 	void setHoverHeight(int height);
 	
 	int getHoverHeight();
+
+	void setJumpedFromBlock(boolean state);
+
+	boolean jumpedFromBlock();
 }

--- a/src/main/java/com/superworldsun/superslegend/mixin/MixinPlayerEntity.java
+++ b/src/main/java/com/superworldsun/superslegend/mixin/MixinPlayerEntity.java
@@ -39,8 +39,11 @@ public abstract class MixinPlayerEntity extends LivingEntity
 	private float targetRenderScale = 1.0F;
 	private float renderScale = 1.0F;
 	private float prevRenderScale = 1.0F;
+
 	private int hoverTime;
 	private int hoverHeight;
+	private boolean jumpedFromGround;
+
 	private boolean isLit;
 	private EntityLightEmitter lightEmitter = new EntityLightEmitter(this::getCommandSenderWorld, this::getLookAngle, this::position, this);
 	
@@ -176,6 +179,14 @@ public abstract class MixinPlayerEntity extends LivingEntity
 	{
 		return hoverHeight;
 	}
+
+	@Override
+	public boolean jumpedFromBlock() { return jumpedFromGround; }
+
+	@Override
+	public void setJumpedFromBlock(boolean state) {
+		jumpedFromGround = state;
+	}
 	
 	@Override
 	public boolean isSwimming()
@@ -188,7 +199,7 @@ public abstract class MixinPlayerEntity extends LivingEntity
 	{
 		return jumping;
 	}
-	
+
 	@Override
 	public void receiveLight()
 	{

--- a/src/main/java/com/superworldsun/superslegend/util/PlayerUtil.java
+++ b/src/main/java/com/superworldsun/superslegend/util/PlayerUtil.java
@@ -1,0 +1,24 @@
+package com.superworldsun.superslegend.util;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+public class PlayerUtil {
+    /**
+     *
+     * @param player The Player
+     * @param checkHeight How many blocks under the player's foot must be clear (Not Solid)
+     * @return false, if all blocks are not solid. true, if one of the blocks is solid
+     */
+    public static boolean solidGroundCheck(PlayerEntity player, int checkHeight) {
+        BlockPos currentPos = player.blockPosition();
+
+            for (int i = 0; i < checkHeight; i++) {
+                if (player.getCommandSenderWorld().getBlockState(currentPos).getMaterial().isSolid()) {
+                    return true;
+                }
+                currentPos = currentPos.below();
+            }
+        return false;
+    }
+}


### PR DESCRIPTION
Modified Hover Boots, so

- Jumping from a block doesn't activate "hover mode"
- The player must sprint in order to activate "hover mode"
- 1 block must be free/not solid under the players foot (Can be changed or completly disabled)

And added a PlayerUtil class, with a solidGroundCheck function, that checks if a given amount of blocks under the players foot is not solid.