### PR TITLE
Port transformation masks

### DIFF
--- a/src/main/java/com/superworldsun/superslegend/client/events/PlayerTransformationEvents.java
+++ b/src/main/java/com/superworldsun/superslegend/client/events/PlayerTransformationEvents.java
@@ -1,0 +1,46 @@
+package com.superworldsun.superslegend.client.events;
+
+import com.superworldsun.superslegend.SupersLegendMain;
+import com.superworldsun.superslegend.interfaces.IHandRenderer;
+import com.superworldsun.superslegend.interfaces.IPlayerModelChanger;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderArmEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = SupersLegendMain.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+public class PlayerTransformationEvents {
+    @SubscribeEvent
+    public static void onRenderArm(RenderArmEvent event) {
+        AbstractClientPlayer player = event.getPlayer();
+        IPlayerModelChanger changer = IPlayerModelChanger.get(player);
+
+        if (changer == null) {
+            return;
+        }
+
+        PlayerModel<AbstractClientPlayer> model = changer.getPlayerModel(player);
+        ResourceLocation texture = changer.getPlayerTexture(player);
+        model.attackTime = 0.0F;
+        model.crouching = false;
+        model.swimAmount = 0.0F;
+        model.leftArmPose = HumanoidModel.ArmPose.EMPTY;
+        model.rightArmPose = HumanoidModel.ArmPose.EMPTY;
+        model.setupAnim(player, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F);
+        boolean rightArm = event.getArm() == HumanoidArm.RIGHT;
+        ModelPart hand = rightArm ? model.rightArm : model.leftArm;
+        ModelPart handOverlay = rightArm ? model.rightSleeve : model.leftSleeve;
+
+        if (model instanceof IHandRenderer handRenderer) {
+            handRenderer.renderFirstPersonHand(event.getPoseStack(), event.getMultiBufferSource(), event.getPackedLight(), player, hand, handOverlay, texture);
+        }
+
+        event.setCanceled(true);
+    }
+}

--- a/src/main/java/com/superworldsun/superslegend/client/handler/ClientModHandler.java
+++ b/src/main/java/com/superworldsun/superslegend/client/handler/ClientModHandler.java
@@ -7,6 +7,9 @@ import com.superworldsun.superslegend.client.model.OpenOwlStatueModel;
 import com.superworldsun.superslegend.client.model.OwlStatueModel;
 import com.superworldsun.superslegend.client.model.hooks.HookshotModel;
 import com.superworldsun.superslegend.client.model.hooks.LongshotModel;
+import com.superworldsun.superslegend.client.model.player.DekuPlayerModel;
+import com.superworldsun.superslegend.client.model.player.GoronPlayerModel;
+import com.superworldsun.superslegend.client.model.player.ZoraPlayerModel;
 import com.superworldsun.superslegend.client.render.blocks.*;
 import com.superworldsun.superslegend.client.render.hookshot.HookshotRender;
 import com.superworldsun.superslegend.client.screen.PostboxScreen;
@@ -50,5 +53,8 @@ public class ClientModHandler {
         event.registerLayerDefinition(ModelLayers.FAN, FanModel::createBodyLayer);
         event.registerLayerDefinition(ModelLayers.HOOKSHOT, HookshotModel::createBodyLayer);
         event.registerLayerDefinition(ModelLayers.LONGSHOT, LongshotModel::createBodyLayer);
+        event.registerLayerDefinition(ModelLayers.GORON_PLAYER, GoronPlayerModel::createLayer);
+        event.registerLayerDefinition(ModelLayers.ZORA_PLAYER, ZoraPlayerModel::createLayer);
+        event.registerLayerDefinition(ModelLayers.DEKU_PLAYER, DekuPlayerModel::createLayer);
     }
 }

--- a/src/main/java/com/superworldsun/superslegend/client/model/ModelLayers.java
+++ b/src/main/java/com/superworldsun/superslegend/client/model/ModelLayers.java
@@ -10,5 +10,8 @@ public class ModelLayers {
     public static final ModelLayerLocation FAN = new ModelLayerLocation(new ResourceLocation(SupersLegendMain.MOD_ID, "fan"), "main");
     public static final ModelLayerLocation HOOKSHOT = new ModelLayerLocation(new ResourceLocation(SupersLegendMain.MOD_ID, "hookshot"), "main");
     public static final ModelLayerLocation LONGSHOT = new ModelLayerLocation(new ResourceLocation(SupersLegendMain.MOD_ID, "longshot"), "main");
+    public static final ModelLayerLocation GORON_PLAYER = new ModelLayerLocation(new ResourceLocation(SupersLegendMain.MOD_ID, "goron_player"), "main");
+    public static final ModelLayerLocation ZORA_PLAYER = new ModelLayerLocation(new ResourceLocation(SupersLegendMain.MOD_ID, "zora_player"), "main");
+    public static final ModelLayerLocation DEKU_PLAYER = new ModelLayerLocation(new ResourceLocation(SupersLegendMain.MOD_ID, "deku_player"), "main");
 
 }

--- a/src/main/java/com/superworldsun/superslegend/client/model/player/DekuPlayerModel.java
+++ b/src/main/java/com/superworldsun/superslegend/client/model/player/DekuPlayerModel.java
@@ -1,0 +1,382 @@
+package com.superworldsun.superslegend.client.model.player;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.superworldsun.superslegend.interfaces.IHandRenderer;
+import net.minecraft.client.model.AnimationUtils;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.HumanoidArm;
+
+public class DekuPlayerModel extends PlayerModel<AbstractClientPlayer> implements IHandRenderer {
+    public DekuPlayerModel(ModelPart root) {
+        super(root, false);
+    }
+
+    public static LayerDefinition createLayer() {
+        MeshDefinition mesh = PlayerModel.createMesh(CubeDeformation.NONE, false);
+        PartDefinition root = mesh.getRoot();
+
+        // Vanilla overlay parts are unused by this model, replace them with empty parts
+        root.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("ear", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("cloak", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("jacket", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("left_sleeve", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("right_sleeve", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("left_pants", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("right_pants", CubeListBuilder.create(), PartPose.ZERO);
+
+        PartDefinition body = root.addOrReplaceChild("body", CubeListBuilder.create()
+                .texOffs(33, 0).addBox(-3.5F, 3.0F, -2.5F, 7.0F, 4.0F, 5.0F)
+                .texOffs(20, 42).addBox(-3.0F, 0.0F, -2.0F, 6.0F, 3.0F, 4.0F),
+                PartPose.offset(0.0F, 8.0F, 0.0F));
+        body.addOrReplaceChild("cube_r1", CubeListBuilder.create()
+                .texOffs(0, 14).addBox(0.0F, -1.0F, -3.5F, 0.0F, 2.0F, 5.0F),
+                PartPose.offsetAndRotation(3.8836F, 7.9235F, 1.0F, 0.0F, 0.0F, -0.3927F));
+        body.addOrReplaceChild("cube_r2", CubeListBuilder.create()
+                .texOffs(0, 16).addBox(0.0F, -1.0F, -3.5F, 0.0F, 2.0F, 5.0F),
+                PartPose.offsetAndRotation(-3.8827F, 7.9239F, 1.0F, 0.0F, 0.0F, 0.3927F));
+        body.addOrReplaceChild("cube_r3", CubeListBuilder.create()
+                .texOffs(16, 39).addBox(-3.5F, 0.0F, 0.0F, 7.0F, 2.0F, 0.0F),
+                PartPose.offsetAndRotation(0.0F, 7.0F, 2.5F, 0.3927F, 0.0F, 0.0F));
+        body.addOrReplaceChild("cube_r4", CubeListBuilder.create()
+                .texOffs(51, 10).addBox(-3.5F, 0.0F, 0.0F, 7.0F, 2.0F, 0.0F),
+                PartPose.offsetAndRotation(0.0F, 6.9996F, -2.5009F, -0.3927F, 0.0F, 0.0F));
+
+        PartDefinition rightLeg = root.addOrReplaceChild("right_leg", CubeListBuilder.create(),
+                PartPose.offset(2.0F, 16.0F, -0.5F));
+        rightLeg.addOrReplaceChild("cube_r5", CubeListBuilder.create()
+                .texOffs(54, 6).addBox(2.3695F, -1.125F, -11.8814F, 3.0F, 1.0F, 3.0F)
+                .texOffs(20, 41).addBox(3.3695F, -5.125F, -10.8814F, 1.0F, 4.0F, 1.0F)
+                .texOffs(36, 42).addBox(2.8695F, -0.125F, -11.3814F, 2.0F, 2.0F, 2.0F)
+                .texOffs(15, 49).addBox(2.3695F, 1.875F, -13.8814F, 3.0F, 2.0F, 5.0F),
+                PartPose.offsetAndRotation(-7.5F, 4.125F, 8.25F, 0.0F, -0.3927F, 0.0F));
+
+        PartDefinition leftLeg = root.addOrReplaceChild("left_leg", CubeListBuilder.create(),
+                PartPose.offset(-2.5F, 16.0F, -0.5F));
+        leftLeg.addOrReplaceChild("cube_r6", CubeListBuilder.create()
+                .texOffs(52, 0).addBox(-1.5F, -1.125F, -1.25F, 3.0F, 1.0F, 3.0F)
+                .texOffs(33, 0).addBox(-0.5F, -5.125F, -0.25F, 1.0F, 4.0F, 1.0F)
+                .texOffs(0, 23).addBox(-1.0F, -0.125F, -0.75F, 2.0F, 2.0F, 2.0F)
+                .texOffs(40, 42).addBox(-1.5F, 1.875F, -3.25F, 3.0F, 2.0F, 5.0F),
+                PartPose.offsetAndRotation(0.0F, 4.125F, 0.25F, 0.0F, 0.3927F, 0.0F));
+
+        PartDefinition leftArm = root.addOrReplaceChild("left_arm", CubeListBuilder.create(),
+                PartPose.offset(4.0F, 9.5F, 0.5F));
+        leftArm.addOrReplaceChild("cube_r7", CubeListBuilder.create()
+                .texOffs(0, 50).addBox(-1.5F, 6.5F, -1.5F, 3.0F, 3.0F, 3.0F)
+                .texOffs(54, 47).addBox(-1.0F, 5.5F, -1.0F, 2.0F, 1.0F, 2.0F)
+                .texOffs(51, 42).addBox(-1.5F, 4.5F, -1.5F, 3.0F, 1.0F, 3.0F)
+                .texOffs(30, 24).addBox(-0.5F, 0.5F, -0.5F, 1.0F, 4.0F, 1.0F)
+                .texOffs(0, 4).addBox(-1.0F, -1.5F, -1.0F, 2.0F, 2.0F, 2.0F),
+                PartPose.offsetAndRotation(0.0F, 0.0F, 0.0F, 0.0F, 0.0F, -0.3927F));
+
+        PartDefinition rightArm = root.addOrReplaceChild("right_arm", CubeListBuilder.create(),
+                PartPose.offset(-4.0F, 9.5F, 0.5F));
+        rightArm.addOrReplaceChild("cube_r8", CubeListBuilder.create()
+                .texOffs(45, 49).addBox(-1.5F, 6.5F, -1.5F, 3.0F, 3.0F, 3.0F)
+                .texOffs(9, 50).addBox(-1.0F, 5.5F, -1.0F, 2.0F, 1.0F, 2.0F)
+                .texOffs(42, 9).addBox(-1.5F, 4.5F, -1.5F, 3.0F, 1.0F, 3.0F)
+                .texOffs(30, 19).addBox(-0.5F, 0.5F, -0.5F, 1.0F, 4.0F, 1.0F)
+                .texOffs(0, 0).addBox(-1.0F, -1.5F, -1.0F, 2.0F, 2.0F, 2.0F),
+                PartPose.offsetAndRotation(0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.3927F));
+
+        PartDefinition head = root.addOrReplaceChild("head", CubeListBuilder.create()
+                .texOffs(0, 19).addBox(-5.0F, -10.0F, -5.0F, 10.0F, 10.0F, 10.0F)
+                .texOffs(0, 39).addBox(-3.0F, 2.305F, 7.7802F, 6.0F, 7.0F, 4.0F)
+                .texOffs(31, 49).addBox(-2.5F, -5.0F, -7.0F, 5.0F, 5.0F, 2.0F),
+                PartPose.offset(0.0F, 8.0F, 0.0F));
+        head.addOrReplaceChild("cube_r9", CubeListBuilder.create()
+                .texOffs(26, 49).addBox(-6.0F, 4.75F, -10.0F, 2.0F, 3.0F, 0.0F)
+                .texOffs(6, 21).addBox(-5.5F, 4.75F, -9.0F, 0.0F, 2.0F, 2.0F)
+                .texOffs(0, 25).addBox(5.5F, 4.75F, -9.0F, 0.0F, 2.0F, 2.0F)
+                .texOffs(45, 55).addBox(4.0F, 4.75F, -10.0F, 2.0F, 3.0F, 0.0F)
+                .texOffs(0, 39).addBox(-1.0F, 4.75F, -10.0F, 2.0F, 4.0F, 0.0F)
+                .texOffs(4, 27).addBox(-3.5F, 4.75F, -10.0F, 2.0F, 2.0F, 0.0F)
+                .texOffs(49, 55).addBox(1.5F, 4.75F, -10.0F, 2.0F, 3.0F, 0.0F)
+                .texOffs(30, 29).addBox(-5.5F, 1.75F, -10.0F, 11.0F, 3.0F, 10.0F),
+                PartPose.offsetAndRotation(0.0F, -10.5F, 6.0F, -0.3927F, 0.0F, 0.0F));
+        head.addOrReplaceChild("cube_r10", CubeListBuilder.create()
+                .texOffs(36, 13).addBox(-4.0F, -5.5F, -5.5F, 8.0F, 10.0F, 6.0F),
+                PartPose.offsetAndRotation(0.0F, -1.6612F, 10.5962F, 0.3927F, 0.0F, 0.0F));
+        head.addOrReplaceChild("cube_r11", CubeListBuilder.create()
+                .texOffs(0, 0).addBox(-6.0F, -5.0F, -8.5F, 12.0F, 10.0F, 9.0F),
+                PartPose.offsetAndRotation(0.0F, -10.5F, 6.0F, 0.7854F, 0.0F, 0.0F));
+
+        return LayerDefinition.create(mesh, 128, 128);
+    }
+
+    @Override
+    public void setupAnim(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        // The model instance is reused between frames, restore the default pose first
+        this.head.resetPose();
+        this.body.resetPose();
+        this.leftArm.resetPose();
+        this.rightArm.resetPose();
+        this.leftLeg.resetPose();
+        this.rightLeg.resetPose();
+
+        boolean flag = player.getFallFlyingTicks() > 4;
+        boolean flag1 = player.isVisuallySwimming();
+        this.head.yRot = netHeadYaw * ((float) Math.PI / 180F);
+        if (flag) {
+            this.head.xRot = (-(float) Math.PI / 4F);
+        } else if (this.swimAmount > 0.0F) {
+            if (flag1) {
+                this.head.xRot = this.rotlerpRad(this.swimAmount, this.head.xRot, (-(float) Math.PI / 4F));
+            } else {
+                this.head.xRot = this.rotlerpRad(this.swimAmount, this.head.xRot, headPitch * ((float) Math.PI / 180F));
+            }
+        } else {
+            this.head.xRot = headPitch * ((float) Math.PI / 180F);
+        }
+
+        this.body.yRot = 0.0F;
+        this.rightArm.z = 0.5F;
+        this.rightArm.x = -4.0F;
+        this.leftArm.z = 0.5F;
+        this.leftArm.x = 4.0F;
+        float f = 1.0F;
+        if (flag) {
+            f = (float) player.getDeltaMovement().lengthSqr();
+            f = f / 0.2F;
+            f = f * f * f;
+        }
+
+        if (f < 1.0F) {
+            f = 1.0F;
+        }
+
+        this.rightArm.xRot = Mth.cos(limbSwing * 0.6662F + (float) Math.PI) * 2.0F * limbSwingAmount * 0.5F / f;
+        this.leftArm.xRot = Mth.cos(limbSwing * 0.6662F) * 2.0F * limbSwingAmount * 0.5F / f;
+        this.rightArm.zRot = 0.0F;
+        this.leftArm.zRot = 0.0F;
+        this.rightLeg.xRot = Mth.cos(limbSwing * 0.6662F) * 1.4F * limbSwingAmount / f;
+        this.leftLeg.xRot = Mth.cos(limbSwing * 0.6662F + (float) Math.PI) * 1.4F * limbSwingAmount / f;
+        this.rightLeg.yRot = 0.0F;
+        this.leftLeg.yRot = 0.0F;
+        this.rightLeg.zRot = 0.0F;
+        this.leftLeg.zRot = 0.0F;
+        if (this.riding) {
+            this.rightArm.xRot += (-(float) Math.PI / 5F);
+            this.leftArm.xRot += (-(float) Math.PI / 5F);
+            this.rightLeg.xRot = -1.4137167F;
+            this.rightLeg.yRot = ((float) Math.PI / 10F);
+            this.rightLeg.zRot = 0.07853982F;
+            this.leftLeg.xRot = -1.4137167F;
+            this.leftLeg.yRot = (-(float) Math.PI / 10F);
+            this.leftLeg.zRot = -0.07853982F;
+        }
+
+        this.rightArm.yRot = 0.0F;
+        this.leftArm.yRot = 0.0F;
+        boolean flag2 = player.getMainArm() == HumanoidArm.RIGHT;
+        boolean flag3 = flag2 ? this.leftArmPose.isTwoHanded() : this.rightArmPose.isTwoHanded();
+        if (flag2 != flag3) {
+            this.poseLeftArm(player);
+            this.poseRightArm(player);
+        } else {
+            this.poseRightArm(player);
+            this.poseLeftArm(player);
+        }
+
+        this.setupAttackAnimation(player, ageInTicks);
+        if (this.crouching) {
+            this.body.xRot = 0.5F;
+            this.rightArm.xRot += 0.4F;
+            this.leftArm.xRot += 0.4F;
+            this.rightLeg.z = 3.5F;
+            this.leftLeg.z = 3.5F;
+            this.rightLeg.y = 16.2F;
+            this.leftLeg.y = 16.2F;
+            this.head.y = 12.2F;
+            this.body.y = 11.2F;
+            this.leftArm.y = 12.7F;
+            this.rightArm.y = 12.7F;
+        } else {
+            this.body.xRot = 0.0F;
+            this.rightLeg.z = -0.4F;
+            this.leftLeg.z = -0.4F;
+            this.rightLeg.y = 16.0F;
+            this.leftLeg.y = 16.0F;
+            this.head.y = 8.0F;
+            this.body.y = 8.0F;
+            this.leftArm.y = 9.5F;
+            this.rightArm.y = 9.5F;
+        }
+
+        AnimationUtils.bobArms(this.rightArm, this.leftArm, ageInTicks);
+        if (this.swimAmount > 0.0F) {
+            float f1 = limbSwing % 26.0F;
+            HumanoidArm handside = this.getSwingingArm(player);
+            float f2 = handside == HumanoidArm.RIGHT && this.attackTime > 0.0F ? 0.0F : this.swimAmount;
+            float f3 = handside == HumanoidArm.LEFT && this.attackTime > 0.0F ? 0.0F : this.swimAmount;
+            if (f1 < 14.0F) {
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, 0.0F);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, 0.0F);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, (float) Math.PI + 1.8707964F * this.quadraticArmUpdate(f1) / this.quadraticArmUpdate(14.0F));
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, (float) Math.PI - 1.8707964F * this.quadraticArmUpdate(f1) / this.quadraticArmUpdate(14.0F));
+            } else if (f1 >= 14.0F && f1 < 22.0F) {
+                float f6 = (f1 - 14.0F) / 8.0F;
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, ((float) Math.PI / 2F) * f6);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, ((float) Math.PI / 2F) * f6);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, 5.012389F - 1.8707964F * f6);
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, 1.2707963F + 1.8707964F * f6);
+            } else if (f1 >= 22.0F && f1 < 26.0F) {
+                float f4 = (f1 - 22.0F) / 4.0F;
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, ((float) Math.PI / 2F) - ((float) Math.PI / 2F) * f4);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, ((float) Math.PI / 2F) - ((float) Math.PI / 2F) * f4);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, (float) Math.PI);
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, (float) Math.PI);
+            }
+
+            this.leftLeg.xRot = Mth.lerp(this.swimAmount, this.leftLeg.xRot, 0.3F * Mth.cos(limbSwing * 0.33333334F + (float) Math.PI));
+            this.rightLeg.xRot = Mth.lerp(this.swimAmount, this.rightLeg.xRot, 0.3F * Mth.cos(limbSwing * 0.33333334F));
+        }
+
+        this.hat.copyFrom(this.head);
+    }
+
+    @Override
+    protected void setupAttackAnimation(AbstractClientPlayer player, float ageInTicks) {
+        if (!(this.attackTime <= 0.0F)) {
+            HumanoidArm handside = this.getSwingingArm(player);
+            ModelPart modelrenderer = this.getArm(handside);
+            float f = this.attackTime;
+            this.body.yRot = Mth.sin(Mth.sqrt(f) * ((float) Math.PI * 2F)) * 0.2F;
+            if (handside == HumanoidArm.LEFT) {
+                this.body.yRot *= -1.0F;
+            }
+
+            this.rightArm.z = Mth.sin(this.body.yRot) * 4.0F;
+            this.rightArm.x = -Mth.cos(this.body.yRot) * 4.0F;
+            this.leftArm.z = -Mth.sin(this.body.yRot) * 4.0F;
+            this.leftArm.x = Mth.cos(this.body.yRot) * 4.0F;
+            this.rightArm.yRot += this.body.yRot;
+            this.leftArm.yRot += this.body.yRot;
+            this.leftArm.xRot += this.body.yRot;
+            f = 1.0F - this.attackTime;
+            f = f * f;
+            f = f * f;
+            f = 1.0F - f;
+            float f1 = Mth.sin(f * (float) Math.PI);
+            float f2 = Mth.sin(this.attackTime * (float) Math.PI) * -(this.head.xRot - 0.7F) * 0.75F;
+            modelrenderer.xRot = (float) ((double) modelrenderer.xRot - ((double) f1 * 1.2D + (double) f2));
+            modelrenderer.yRot += this.body.yRot * 2.0F;
+            modelrenderer.zRot += Mth.sin(this.attackTime * (float) Math.PI) * -0.4F;
+        }
+    }
+
+    private float quadraticArmUpdate(float f) {
+        return -65.0F * f + f * f;
+    }
+
+    private HumanoidArm getSwingingArm(AbstractClientPlayer player) {
+        HumanoidArm humanoidarm = player.getMainArm();
+        return player.swingingArm == InteractionHand.MAIN_HAND ? humanoidarm : humanoidarm.getOpposite();
+    }
+
+    private void poseRightArm(AbstractClientPlayer player) {
+        switch (this.rightArmPose) {
+            case EMPTY:
+                this.rightArm.yRot = 0.0F;
+                break;
+            case BLOCK:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - 0.9424779F;
+                this.rightArm.yRot = (-(float) Math.PI / 6F);
+                break;
+            case ITEM:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - ((float) Math.PI / 10F);
+                this.rightArm.yRot = 0.0F;
+                break;
+            case THROW_SPEAR:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - (float) Math.PI;
+                this.rightArm.yRot = 0.0F;
+                break;
+            case BOW_AND_ARROW:
+                this.rightArm.yRot = -0.1F + this.head.yRot;
+                this.leftArm.yRot = 0.1F + this.head.yRot + 0.4F;
+                this.rightArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                this.leftArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                break;
+            case CROSSBOW_CHARGE:
+                AnimationUtils.animateCrossbowCharge(this.rightArm, this.leftArm, player, true);
+                break;
+            case CROSSBOW_HOLD:
+                AnimationUtils.animateCrossbowHold(this.rightArm, this.leftArm, this.head, true);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void poseLeftArm(AbstractClientPlayer player) {
+        switch (this.leftArmPose) {
+            case EMPTY:
+                this.leftArm.yRot = 0.0F;
+                break;
+            case BLOCK:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - 0.9424779F;
+                this.leftArm.yRot = ((float) Math.PI / 6F);
+                break;
+            case ITEM:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - ((float) Math.PI / 10F);
+                this.leftArm.yRot = 0.0F;
+                break;
+            case THROW_SPEAR:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - (float) Math.PI;
+                this.leftArm.yRot = 0.0F;
+                break;
+            case BOW_AND_ARROW:
+                this.rightArm.yRot = -0.1F + this.head.yRot - 0.4F;
+                this.leftArm.yRot = 0.1F + this.head.yRot;
+                this.rightArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                this.leftArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                break;
+            case CROSSBOW_CHARGE:
+                AnimationUtils.animateCrossbowCharge(this.rightArm, this.leftArm, player, false);
+                break;
+            case CROSSBOW_HOLD:
+                AnimationUtils.animateCrossbowHold(this.rightArm, this.leftArm, this.head, false);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    protected Iterable<ModelPart> bodyParts() {
+        return ImmutableList.of(this.body, this.rightArm, this.leftArm, this.rightLeg, this.leftLeg);
+    }
+
+    @Override
+    public void renderFirstPersonHand(PoseStack poseStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, ModelPart hand, ModelPart handOverlay,
+            ResourceLocation texture) {
+        hand.xRot = 0;
+        hand.y = 7.5F;
+        hand.render(poseStack, buffer.getBuffer(RenderType.entitySolid(texture)), packedLight, OverlayTexture.NO_OVERLAY);
+        handOverlay.xRot = 0;
+        handOverlay.y = 7.5F;
+        handOverlay.render(poseStack, buffer.getBuffer(RenderType.entityTranslucent(texture)), packedLight, OverlayTexture.NO_OVERLAY);
+    }
+}

--- a/src/main/java/com/superworldsun/superslegend/client/model/player/GoronPlayerModel.java
+++ b/src/main/java/com/superworldsun/superslegend/client/model/player/GoronPlayerModel.java
@@ -1,0 +1,397 @@
+package com.superworldsun.superslegend.client.model.player;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.superworldsun.superslegend.interfaces.IHandRenderer;
+import net.minecraft.client.model.AnimationUtils;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.HumanoidArm;
+
+public class GoronPlayerModel extends PlayerModel<AbstractClientPlayer> implements IHandRenderer {
+    public GoronPlayerModel(ModelPart root) {
+        super(root, false);
+    }
+
+    public static LayerDefinition createLayer() {
+        MeshDefinition mesh = PlayerModel.createMesh(CubeDeformation.NONE, false);
+        PartDefinition root = mesh.getRoot();
+
+        // Vanilla overlay parts are unused by this model, replace them with empty parts
+        root.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("ear", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("cloak", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("jacket", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("left_sleeve", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("right_sleeve", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("left_pants", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("right_pants", CubeListBuilder.create(), PartPose.ZERO);
+
+        PartDefinition head = root.addOrReplaceChild("head", CubeListBuilder.create()
+                .texOffs(0, 48).addBox(-5.0814F, -7.9139F, -4.6716F, 10.0F, 10.0F, 11.0F),
+                PartPose.offset(0.0814F, -15.0861F, -0.3284F));
+        head.addOrReplaceChild("cube_r1", CubeListBuilder.create()
+                .texOffs(84, 78).addBox(4.0F, -10.0F, 9.0F, 5.0F, 10.0F, 4.0F),
+                PartPose.offsetAndRotation(-6.5814F, 11.0861F, 1.3284F, 0.0873F, 0.0F, 0.0F));
+        head.addOrReplaceChild("cube_r2", CubeListBuilder.create()
+                .texOffs(62, 0).addBox(3.0F, -10.0F, 11.0F, 7.0F, 10.0F, 6.0F),
+                PartPose.offsetAndRotation(-6.5814F, 11.0861F, 1.3284F, 0.6981F, 0.0F, 0.0F));
+        head.addOrReplaceChild("cube_r3", CubeListBuilder.create()
+                .texOffs(42, 36).addBox(1.0F, 5.0F, 6.25F, 11.0F, 8.0F, 12.0F),
+                PartPose.offsetAndRotation(-6.5814F, 11.0861F, 1.3284F, 1.9635F, 0.0F, 0.0F));
+        head.addOrReplaceChild("cube_r4", CubeListBuilder.create()
+                .texOffs(0, 0).addBox(-14.5F, -17.0F, -12.5F, 5.0F, 9.0F, 0.0F),
+                PartPose.offsetAndRotation(8.4186F, 11.0861F, 1.3284F, -0.2954F, 0.3687F, -0.0904F));
+        head.addOrReplaceChild("cube_r5", CubeListBuilder.create()
+                .texOffs(0, 28).addBox(7.5F, -17.0F, -12.0F, 5.0F, 9.0F, 0.0F),
+                PartPose.offsetAndRotation(-6.5814F, 11.0861F, 1.3284F, -0.2954F, -0.3687F, 0.0904F));
+        head.addOrReplaceChild("cube_r6", CubeListBuilder.create()
+                .texOffs(7, 0).addBox(3.5F, -17.0F, 9.25F, 2.0F, 0.0F, 3.0F)
+                .texOffs(7, 3).addBox(7.5F, -17.0F, 9.25F, 2.0F, 0.0F, 3.0F),
+                PartPose.offsetAndRotation(-6.5814F, 10.3394F, 3.8026F, 1.0908F, 0.0F, 0.0F));
+        head.addOrReplaceChild("cube_r7", CubeListBuilder.create()
+                .texOffs(8, 6).addBox(7.5F, -17.0F, -11.75F, 2.0F, 0.0F, 2.0F)
+                .texOffs(8, 8).addBox(3.5F, -17.0F, -11.75F, 2.0F, 0.0F, 2.0F),
+                PartPose.offsetAndRotation(-6.5814F, 11.0861F, 1.3284F, -0.2618F, 0.0F, 0.0F));
+
+        PartDefinition body = root.addOrReplaceChild("body", CubeListBuilder.create()
+                .texOffs(0, 0).addBox(-7.9901F, -5.0313F, -7.1092F, 16.0F, 13.0F, 15.0F)
+                .texOffs(0, 28).addBox(-6.9901F, -12.0313F, -5.1092F, 14.0F, 7.0F, 13.0F)
+                .texOffs(47, 0).addBox(-4.9901F, 7.9688F, -3.1092F, 10.0F, 4.0F, 0.0F)
+                .texOffs(0, 9).addBox(-1.4901F, -10.0313F, -8.1092F, 3.0F, 3.0F, 3.0F),
+                PartPose.offset(-0.0099F, -0.9688F, 0.1092F));
+        body.addOrReplaceChild("cube_r8", CubeListBuilder.create().mirror()
+                .texOffs(0, 9).addBox(1.0F, 0.75F, -16.75F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(3.3246F, -11.5313F, -4.7411F, -3.1416F, 0.3927F, -3.1416F));
+        body.addOrReplaceChild("cube_r9", CubeListBuilder.create()
+                .texOffs(0, 9).addBox(-2.0F, 0.75F, -16.0F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(-1.3047F, -11.5313F, -4.7411F, -3.1416F, -0.3927F, 3.1416F));
+        body.addOrReplaceChild("cube_r10", CubeListBuilder.create().mirror()
+                .texOffs(0, 9).addBox(-6.5F, 0.0F, -15.0F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(3.3246F, -11.5313F, -4.7411F, -3.1416F, 1.1345F, -3.1416F));
+        body.addOrReplaceChild("cube_r11", CubeListBuilder.create()
+                .texOffs(0, 9).addBox(4.5F, 0.0F, -13.25F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(-1.3047F, -11.5313F, -4.7411F, -3.1416F, -1.1345F, 3.1416F));
+        body.addOrReplaceChild("cube_r12", CubeListBuilder.create().mirror()
+                .texOffs(0, 9).addBox(-8.25F, -1.75F, -12.25F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(3.3246F, -11.5313F, -4.7411F, 0.0F, 1.5708F, 0.0F));
+        body.addOrReplaceChild("cube_r13", CubeListBuilder.create()
+                .texOffs(0, 9).addBox(5.25F, -1.75F, -10.25F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(-1.3047F, -11.5313F, -4.7411F, 0.0F, -1.5708F, 0.0F));
+        body.addOrReplaceChild("cube_r14", CubeListBuilder.create().mirror()
+                .texOffs(0, 9).addBox(-6.0F, -0.75F, -11.5F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(3.3246F, -11.5313F, -4.7411F, 0.0F, 1.4399F, 0.0F));
+        body.addOrReplaceChild("cube_r15", CubeListBuilder.create()
+                .texOffs(0, 9).addBox(2.75F, -0.75F, -9.5F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(-1.3047F, -11.5313F, -4.7411F, 0.0F, -1.4399F, 0.0F));
+        body.addOrReplaceChild("cube_r16", CubeListBuilder.create().mirror()
+                .texOffs(0, 9).addBox(-5.0F, -0.75F, -7.5F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(0.9216F, -10.7813F, -4.1085F, 0.0F, 1.0036F, 0.0F));
+        body.addOrReplaceChild("cube_r17", CubeListBuilder.create()
+                .texOffs(0, 9).addBox(2.75F, 0.0F, -7.5F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(-1.3047F, -11.5313F, -4.7411F, 0.0F, -1.0036F, 0.0F));
+        body.addOrReplaceChild("cube_r18", CubeListBuilder.create().mirror()
+                .texOffs(0, 9).addBox(-7.5F, 0.0F, -4.0F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(3.1024F, -10.7813F, -5.5086F, 0.0F, 0.3054F, 0.0F));
+        body.addOrReplaceChild("cube_r19", CubeListBuilder.create()
+                .texOffs(0, 9).addBox(2.5F, -2.25F, -3.5F, 3.0F, 3.0F, 3.0F),
+                PartPose.offsetAndRotation(-1.0247F, -8.5313F, -5.3841F, 0.0F, -0.3054F, 0.0F));
+
+        PartDefinition leftArm = root.addOrReplaceChild("left_arm", CubeListBuilder.create(),
+                PartPose.offset(6.0F, -13.0F, 1.0F));
+        leftArm.addOrReplaceChild("cube_r20", CubeListBuilder.create()
+                .texOffs(84, 12).addBox(-2.0F, -6.0F, -2.0F, 4.0F, 12.0F, 4.0F),
+                PartPose.offsetAndRotation(2.8934F, 5.723F, 0.0F, 0.0F, 0.0F, -0.2182F));
+        leftArm.addOrReplaceChild("cube_r21", CubeListBuilder.create()
+                .texOffs(24, 69).addBox(-3.0F, -5.0F, -3.0F, 6.0F, 10.0F, 6.0F),
+                PartPose.offsetAndRotation(5.2742F, 16.4623F, 0.0F, 0.0F, 0.0F, -0.2182F));
+
+        PartDefinition rightArm = root.addOrReplaceChild("right_arm", CubeListBuilder.create(),
+                PartPose.offset(-6.0F, -13.0F, 1.0F));
+        rightArm.addOrReplaceChild("cube_r22", CubeListBuilder.create()
+                .texOffs(68, 78).addBox(-2.0F, -17.0F, -2.0F, 4.0F, 12.0F, 4.0F)
+                .texOffs(0, 69).addBox(-3.0F, -5.0F, -3.0F, 6.0F, 10.0F, 6.0F),
+                PartPose.offsetAndRotation(-5.2742F, 16.4623F, 0.0F, 0.0F, 0.0F, 0.2182F));
+
+        root.addOrReplaceChild("left_leg", CubeListBuilder.create()
+                .texOffs(48, 72).addBox(-2.75F, 2.0F, -1.75F, 5.0F, 9.0F, 5.0F)
+                .texOffs(65, 56).addBox(-3.75F, 11.0F, -2.75F, 7.0F, 4.0F, 7.0F)
+                .texOffs(51, 17).addBox(-3.25F, 14.0F, -7.0F, 6.0F, 5.0F, 11.0F),
+                PartPose.offset(4.0F, 5.0F, 1.0F));
+        root.addOrReplaceChild("right_leg", CubeListBuilder.create()
+                .texOffs(76, 33).addBox(-2.25F, 2.0F, -2.75F, 5.0F, 9.0F, 5.0F)
+                .texOffs(69, 67).addBox(-3.25F, 11.0F, -3.75F, 7.0F, 4.0F, 7.0F)
+                .texOffs(42, 56).addBox(-2.75F, 14.0F, -8.0F, 6.0F, 5.0F, 11.0F),
+                PartPose.offset(-4.0F, 5.0F, 2.0F));
+
+        return LayerDefinition.create(mesh, 128, 128);
+    }
+
+    @Override
+    protected void setupAttackAnimation(AbstractClientPlayer player, float ageInTicks) {
+        if (!(this.attackTime <= 0.0F)) {
+            HumanoidArm handside = this.getSwingingArm(player);
+            ModelPart modelrenderer = this.getArm(handside);
+            float f = this.attackTime;
+            this.body.yRot = Mth.sin(Mth.sqrt(f) * ((float) Math.PI * 2F)) * 0.2F;
+            if (handside == HumanoidArm.LEFT) {
+                this.body.yRot *= -1.0F;
+            }
+            this.rightArm.yRot += this.body.yRot;
+            this.leftArm.yRot += this.body.yRot;
+            this.leftArm.xRot += this.body.yRot;
+            f = 1.0F - this.attackTime;
+            f = f * f;
+            f = f * f;
+            f = 1.0F - f;
+            float f1 = Mth.sin(f * (float) Math.PI);
+            float f2 = Mth.sin(this.attackTime * (float) Math.PI) * -(this.head.xRot - 0.7F) * 0.75F;
+            modelrenderer.xRot = (float) ((double) modelrenderer.xRot - ((double) f1 * 1.2D + (double) f2));
+            modelrenderer.yRot += this.body.yRot * 2.0F;
+            modelrenderer.zRot += Mth.sin(this.attackTime * (float) Math.PI) * -0.4F;
+        }
+    }
+
+    @Override
+    public void setupAnim(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        // The model instance is reused between frames, restore the default pose first
+        this.head.resetPose();
+        this.body.resetPose();
+        this.leftArm.resetPose();
+        this.rightArm.resetPose();
+        this.leftLeg.resetPose();
+        this.rightLeg.resetPose();
+
+        boolean flag = player.getFallFlyingTicks() > 4;
+        boolean flag1 = player.isVisuallySwimming();
+        this.head.yRot = netHeadYaw * ((float) Math.PI / 180F);
+
+        if (flag) {
+            this.head.xRot = (-(float) Math.PI / 4F);
+        } else if (this.swimAmount > 0.0F) {
+            if (flag1) {
+                this.head.xRot = this.rotlerpRad(this.swimAmount, this.head.xRot, (-(float) Math.PI / 4F));
+            } else {
+                this.head.xRot = this.rotlerpRad(this.swimAmount, this.head.xRot, headPitch * ((float) Math.PI / 180F));
+            }
+        } else {
+            this.head.xRot = headPitch * ((float) Math.PI / 180F);
+        }
+
+        this.body.yRot = 0F;
+        this.rightArm.z = 1F;
+        this.rightArm.x = -6F;
+        this.leftArm.z = 1F;
+        this.leftArm.x = 6F;
+        float f = 1.0F;
+
+        if (flag) {
+            f = (float) player.getDeltaMovement().lengthSqr();
+            f = f / 0.2F;
+            f = f * f * f;
+        }
+
+        if (f < 1.0F) {
+            f = 1.0F;
+        }
+
+        this.leftArm.xRot = Mth.cos(limbSwing * 0.6662F + (float) Math.PI) * 2.0F * limbSwingAmount * 0.5F / f;
+        this.rightArm.xRot = Mth.cos(limbSwing * 0.6662F) * 2.0F * limbSwingAmount * 0.5F / f;
+        this.rightLeg.xRot = Mth.cos(limbSwing * 0.6662F) * 1.4F * limbSwingAmount / f;
+        this.leftLeg.xRot = Mth.cos(limbSwing * 0.6662F + (float) Math.PI) * 1.4F * limbSwingAmount / f;
+        this.rightLeg.yRot = 0.0F;
+        this.leftLeg.yRot = 0.0F;
+        this.rightLeg.zRot = 0.0F;
+        this.leftLeg.zRot = 0.0F;
+
+        if (this.riding) {
+            this.rightArm.xRot += (-(float) Math.PI / 5F);
+            this.leftArm.xRot += (-(float) Math.PI / 5F);
+            this.rightLeg.xRot = -1.4137167F;
+            this.rightLeg.yRot = ((float) Math.PI / 10F);
+            this.rightLeg.zRot = 0.07853982F;
+            this.leftLeg.xRot = -1.4137167F;
+            this.leftLeg.yRot = (-(float) Math.PI / 10F);
+            this.leftLeg.zRot = -0.07853982F;
+        }
+
+        this.rightArm.yRot = 0.0F;
+        this.leftArm.yRot = 0.0F;
+        boolean flag2 = player.getMainArm() == HumanoidArm.RIGHT;
+        boolean flag3 = flag2 ? this.leftArmPose.isTwoHanded() : this.rightArmPose.isTwoHanded();
+
+        if (flag2 != flag3) {
+            this.poseLeftArm(player);
+            this.poseRightArm(player);
+        } else {
+            this.poseRightArm(player);
+            this.poseLeftArm(player);
+        }
+
+        this.setupAttackAnimation(player, ageInTicks);
+
+        if (this.crouching) {
+            this.body.xRot = 0.5F;
+            this.rightArm.xRot += 0.4F;
+            this.leftArm.xRot += 0.4F;
+            this.rightLeg.z = 3.5F;
+            this.leftLeg.z = 3.5F;
+            this.rightLeg.y = 2.5F;
+            this.leftLeg.y = 2.5F;
+            this.head.y = -15.0F;
+            this.head.z = -5.0F;
+            this.body.y = -3.0F;
+            this.leftArm.y = -15.0F;
+            this.rightArm.y = -15.0F;
+            this.leftArm.z = -5.0F;
+            this.rightArm.z = -5.0F;
+        }
+
+        AnimationUtils.bobArms(this.rightArm, this.leftArm, ageInTicks);
+
+        if (this.swimAmount > 0.0F) {
+            float f1 = limbSwing % 26.0F;
+            HumanoidArm handside = this.getSwingingArm(player);
+            float f2 = handside == HumanoidArm.RIGHT && this.attackTime > 0.0F ? 0.0F : this.swimAmount;
+            float f3 = handside == HumanoidArm.LEFT && this.attackTime > 0.0F ? 0.0F : this.swimAmount;
+
+            if (f1 < 14.0F) {
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, 0.0F);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, 0.0F);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, (float) Math.PI + 1.8707964F * this.quadraticArmUpdate(f1) / this.quadraticArmUpdate(14.0F));
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, (float) Math.PI - 1.8707964F * this.quadraticArmUpdate(f1) / this.quadraticArmUpdate(14.0F));
+            } else if (f1 >= 14.0F && f1 < 22.0F) {
+                float f6 = (f1 - 14.0F) / 8.0F;
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, ((float) Math.PI / 2F) * f6);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, ((float) Math.PI / 2F) * f6);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, 5.012389F - 1.8707964F * f6);
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, 1.2707963F + 1.8707964F * f6);
+            } else if (f1 >= 22.0F && f1 < 26.0F) {
+                float f4 = (f1 - 22.0F) / 4.0F;
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, ((float) Math.PI / 2F) - ((float) Math.PI / 2F) * f4);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, ((float) Math.PI / 2F) - ((float) Math.PI / 2F) * f4);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, (float) Math.PI);
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, (float) Math.PI);
+            }
+
+            this.leftLeg.xRot = Mth.lerp(this.swimAmount, this.leftLeg.xRot, 0.3F * Mth.cos(limbSwing * 0.33333334F + (float) Math.PI));
+            this.rightLeg.xRot = Mth.lerp(this.swimAmount, this.rightLeg.xRot, 0.3F * Mth.cos(limbSwing * 0.33333334F));
+        }
+
+        this.hat.copyFrom(this.head);
+    }
+
+    private float quadraticArmUpdate(float f) {
+        return -65.0F * f + f * f;
+    }
+
+    private HumanoidArm getSwingingArm(AbstractClientPlayer player) {
+        HumanoidArm humanoidarm = player.getMainArm();
+        return player.swingingArm == InteractionHand.MAIN_HAND ? humanoidarm : humanoidarm.getOpposite();
+    }
+
+    private void poseLeftArm(AbstractClientPlayer player) {
+        switch (this.leftArmPose) {
+            case EMPTY:
+                this.leftArm.yRot = 0.0F;
+                break;
+            case BLOCK:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - 0.9424779F;
+                this.leftArm.yRot = ((float) Math.PI / 6F);
+                break;
+            case ITEM:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - ((float) Math.PI / 10F);
+                this.leftArm.yRot = 0.0F;
+                break;
+            case THROW_SPEAR:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - (float) Math.PI;
+                this.leftArm.yRot = 0.0F;
+                break;
+            case BOW_AND_ARROW:
+                this.rightArm.yRot = -0.1F + this.head.yRot - 0.4F;
+                this.leftArm.yRot = 0.1F + this.head.yRot;
+                this.rightArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                this.leftArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                break;
+            case CROSSBOW_CHARGE:
+                AnimationUtils.animateCrossbowCharge(this.rightArm, this.leftArm, player, false);
+                break;
+            case CROSSBOW_HOLD:
+                AnimationUtils.animateCrossbowHold(this.rightArm, this.leftArm, this.head, false);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void poseRightArm(AbstractClientPlayer player) {
+        switch (this.rightArmPose) {
+            case EMPTY:
+                this.rightArm.yRot = 0.0F;
+                break;
+            case BLOCK:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - 0.9424779F;
+                this.rightArm.yRot = (-(float) Math.PI / 6F);
+                break;
+            case ITEM:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - ((float) Math.PI / 10F);
+                this.rightArm.yRot = 0.0F;
+                break;
+            case THROW_SPEAR:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - (float) Math.PI;
+                this.rightArm.yRot = 0.0F;
+                break;
+            case BOW_AND_ARROW:
+                this.rightArm.yRot = -0.1F + this.head.yRot;
+                this.leftArm.yRot = 0.1F + this.head.yRot + 0.4F;
+                this.rightArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                this.leftArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                break;
+            case CROSSBOW_CHARGE:
+                AnimationUtils.animateCrossbowCharge(this.rightArm, this.leftArm, player, true);
+                break;
+            case CROSSBOW_HOLD:
+                AnimationUtils.animateCrossbowHold(this.rightArm, this.leftArm, this.head, true);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    protected Iterable<ModelPart> bodyParts() {
+        return ImmutableList.of(this.body, this.rightArm, this.leftArm, this.rightLeg, this.leftLeg);
+    }
+
+    @Override
+    public void renderFirstPersonHand(PoseStack poseStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, ModelPart hand, ModelPart handOverlay,
+            ResourceLocation texture) {
+        hand.xRot = 0;
+        hand.x = 0.0F;
+        hand.y = -7.0F;
+        hand.z = 0.0F;
+        hand.render(poseStack, buffer.getBuffer(RenderType.entitySolid(texture)), packedLight, OverlayTexture.NO_OVERLAY);
+        handOverlay.xRot = 0;
+        handOverlay.y = 1.5F;
+        handOverlay.render(poseStack, buffer.getBuffer(RenderType.entityTranslucent(texture)), packedLight, OverlayTexture.NO_OVERLAY);
+    }
+}

--- a/src/main/java/com/superworldsun/superslegend/client/model/player/PlayerTransformationModels.java
+++ b/src/main/java/com/superworldsun/superslegend/client/model/player/PlayerTransformationModels.java
@@ -1,0 +1,40 @@
+package com.superworldsun.superslegend.client.model.player;
+
+import com.superworldsun.superslegend.client.model.ModelLayers;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+/**
+ * Client-side cache for the transformation player models, so they are not rebuilt every frame.
+ */
+@OnlyIn(Dist.CLIENT)
+public class PlayerTransformationModels {
+    private static GoronPlayerModel goron;
+    private static ZoraPlayerModel zora;
+    private static DekuPlayerModel deku;
+
+    public static GoronPlayerModel getGoron() {
+        if (goron == null) {
+            goron = new GoronPlayerModel(Minecraft.getInstance().getEntityModels().bakeLayer(ModelLayers.GORON_PLAYER));
+        }
+
+        return goron;
+    }
+
+    public static ZoraPlayerModel getZora() {
+        if (zora == null) {
+            zora = new ZoraPlayerModel(Minecraft.getInstance().getEntityModels().bakeLayer(ModelLayers.ZORA_PLAYER));
+        }
+
+        return zora;
+    }
+
+    public static DekuPlayerModel getDeku() {
+        if (deku == null) {
+            deku = new DekuPlayerModel(Minecraft.getInstance().getEntityModels().bakeLayer(ModelLayers.DEKU_PLAYER));
+        }
+
+        return deku;
+    }
+}

--- a/src/main/java/com/superworldsun/superslegend/client/model/player/ZoraPlayerModel.java
+++ b/src/main/java/com/superworldsun/superslegend/client/model/player/ZoraPlayerModel.java
@@ -1,0 +1,343 @@
+package com.superworldsun.superslegend.client.model.player;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.superworldsun.superslegend.interfaces.IHandRenderer;
+import net.minecraft.client.model.AnimationUtils;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.HumanoidArm;
+
+public class ZoraPlayerModel extends PlayerModel<AbstractClientPlayer> implements IHandRenderer {
+    public ZoraPlayerModel(ModelPart root) {
+        super(root, false);
+    }
+
+    public static LayerDefinition createLayer() {
+        MeshDefinition mesh = PlayerModel.createMesh(CubeDeformation.NONE, false);
+        PartDefinition root = mesh.getRoot();
+
+        // Vanilla overlay parts are unused by this model, replace them with empty parts
+        root.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("ear", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("cloak", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("jacket", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("left_sleeve", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("right_sleeve", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("left_pants", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("right_pants", CubeListBuilder.create(), PartPose.ZERO);
+
+        PartDefinition head = root.addOrReplaceChild("head", CubeListBuilder.create()
+                .texOffs(0, 0).addBox(-5.0F, -10.0F, -5.0F, 10.0F, 10.0F, 10.0F)
+                .texOffs(0, 55).addBox(5.0F, -6.0F, -4.0F, 1.0F, 7.0F, 4.0F)
+                .texOffs(50, 28).addBox(-6.0F, -6.0F, -4.0F, 1.0F, 7.0F, 4.0F)
+                .texOffs(0, 0).addBox(0.01F, -5.0F, -8.0F, 0.0F, 4.0F, 3.0F),
+                PartPose.offset(0.0F, -8.0F, 2.0F));
+        head.addOrReplaceChild("head_r1", CubeListBuilder.create()
+                .texOffs(40, 0).addBox(1.0F, -45.0F, 23.0F, 4.0F, 4.0F, 8.0F),
+                PartPose.offsetAndRotation(-3.0F, -19.075F, -34.8401F, -1.5708F, 0.0F, 0.0F));
+        head.addOrReplaceChild("head_r2", CubeListBuilder.create()
+                .texOffs(0, 41).addBox(-1.0F, -40.0F, 14.0F, 6.0F, 6.0F, 8.0F),
+                PartPose.offsetAndRotation(-2.0F, -8.8959F, -32.6536F, -1.3526F, 0.0F, 0.0F));
+        head.addOrReplaceChild("head_r3", CubeListBuilder.create()
+                .texOffs(32, 12).addBox(-3.0F, -42.0F, 5.0F, 8.0F, 8.0F, 8.0F),
+                PartPose.offsetAndRotation(-1.0F, 14.6884F, -29.3436F, -0.829F, 0.0F, 0.0F));
+
+        root.addOrReplaceChild("body", CubeListBuilder.create()
+                .texOffs(0, 20).addBox(-5.5F, -16.0F, -3.0F, 11.0F, 16.0F, 5.0F),
+                PartPose.offset(0.0F, 8.0F, 2.0F));
+
+        PartDefinition rightArm = root.addOrReplaceChild("right_arm", CubeListBuilder.create().mirror()
+                .texOffs(23, 52).addBox(-1.9276F, -2.0976F, -2.25F, 4.0F, 18.0F, 5.0F),
+                PartPose.offset(-7.5724F, -5.9024F, 1.25F));
+        rightArm.addOrReplaceChild("right_arm_r1", CubeListBuilder.create().mirror()
+                .texOffs(32, 28).addBox(-6.0F, -43.0F, -1.0F, 9.0F, 24.0F, 0.01F),
+                PartPose.offsetAndRotation(7.5724F, 29.9024F, 0.75F, 0.0F, 0.0F, -0.48F));
+
+        PartDefinition leftArm = root.addOrReplaceChild("left_arm", CubeListBuilder.create()
+                .texOffs(23, 52).addBox(-2.0724F, -2.0976F, -2.25F, 4.0F, 18.0F, 5.0F),
+                PartPose.offset(7.5724F, -5.9024F, 1.25F));
+        leftArm.addOrReplaceChild("left_arm_r1", CubeListBuilder.create()
+                .texOffs(32, 28).addBox(-3.0F, -43.0F, -1.0F, 9.0F, 24.0F, 0.01F),
+                PartPose.offsetAndRotation(-7.5724F, 29.9024F, 0.75F, 0.0F, 0.0F, 0.48F));
+
+        root.addOrReplaceChild("right_leg", CubeListBuilder.create().mirror()
+                .texOffs(45, 47).addBox(-2.5F, -0.25F, -2.5F, 5.0F, 16.0F, 5.0F)
+                .texOffs(30, 0).addBox(-2.5F, 12.75F, -5.5F, 5.0F, 3.0F, 3.0F),
+                PartPose.offset(-3.0F, 8.25F, 1.5F));
+        root.addOrReplaceChild("left_leg", CubeListBuilder.create()
+                .texOffs(45, 47).addBox(-2.5F, -0.25F, -2.5F, 5.0F, 16.0F, 5.0F)
+                .texOffs(30, 0).addBox(-2.5F, 12.75F, -5.5F, 5.0F, 3.0F, 3.0F),
+                PartPose.offset(3.0F, 8.25F, 1.5F));
+
+        return LayerDefinition.create(mesh, 128, 128);
+    }
+
+    @Override
+    protected void setupAttackAnimation(AbstractClientPlayer player, float ageInTicks) {
+        if (!(this.attackTime <= 0.0F)) {
+            HumanoidArm handside = this.getSwingingArm(player);
+            ModelPart modelrenderer = this.getArm(handside);
+            float f = this.attackTime;
+            this.body.yRot = Mth.sin(Mth.sqrt(f) * ((float) Math.PI * 2F)) * 0.2F;
+            if (handside == HumanoidArm.LEFT) {
+                this.body.yRot *= -1.0F;
+            }
+            this.rightArm.yRot += this.body.yRot;
+            this.leftArm.yRot += this.body.yRot;
+            this.leftArm.xRot += this.body.yRot;
+            f = 1.0F - this.attackTime;
+            f = f * f;
+            f = f * f;
+            f = 1.0F - f;
+            float f1 = Mth.sin(f * (float) Math.PI);
+            float f2 = Mth.sin(this.attackTime * (float) Math.PI) * -(this.head.xRot - 0.7F) * 0.75F;
+            modelrenderer.xRot = (float) ((double) modelrenderer.xRot - ((double) f1 * 1.2D + (double) f2));
+            modelrenderer.yRot += this.body.yRot * 2.0F;
+            modelrenderer.zRot += Mth.sin(this.attackTime * (float) Math.PI) * -0.4F;
+        }
+    }
+
+    @Override
+    public void setupAnim(AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        // The model instance is reused between frames, restore the default pose first
+        this.head.resetPose();
+        this.body.resetPose();
+        this.leftArm.resetPose();
+        this.rightArm.resetPose();
+        this.leftLeg.resetPose();
+        this.rightLeg.resetPose();
+
+        boolean flag = player.getFallFlyingTicks() > 4;
+        boolean flag1 = player.isVisuallySwimming();
+        this.head.yRot = netHeadYaw * ((float) Math.PI / 180F);
+
+        if (flag) {
+            this.head.xRot = (-(float) Math.PI / 4F);
+        } else if (this.swimAmount > 0.0F) {
+            if (flag1) {
+                this.head.xRot = this.rotlerpRad(this.swimAmount, this.head.xRot, (-(float) Math.PI / 4F));
+            } else {
+                this.head.xRot = this.rotlerpRad(this.swimAmount, this.head.xRot, headPitch * ((float) Math.PI / 180F));
+            }
+        } else {
+            this.head.xRot = headPitch * ((float) Math.PI / 180F);
+        }
+
+        this.body.yRot = 0F;
+        this.rightArm.z = 1.25F;
+        this.rightArm.x = -7.5724F;
+        this.leftArm.z = 1.25F;
+        this.leftArm.x = 7.5724F;
+        float f = 1.0F;
+
+        if (flag) {
+            f = (float) player.getDeltaMovement().lengthSqr();
+            f = f / 0.2F;
+            f = f * f * f;
+        }
+
+        if (f < 1.0F) {
+            f = 1.0F;
+        }
+
+        this.leftArm.xRot = Mth.cos(limbSwing * 0.6662F + (float) Math.PI) * 2.0F * limbSwingAmount * 0.5F / f;
+        this.rightArm.xRot = Mth.cos(limbSwing * 0.6662F) * 2.0F * limbSwingAmount * 0.5F / f;
+        this.rightLeg.xRot = Mth.cos(limbSwing * 0.6662F) * 1.4F * limbSwingAmount / f;
+        this.leftLeg.xRot = Mth.cos(limbSwing * 0.6662F + (float) Math.PI) * 1.4F * limbSwingAmount / f;
+        this.rightLeg.yRot = 0.0F;
+        this.leftLeg.yRot = 0.0F;
+        this.rightLeg.zRot = 0.0F;
+        this.leftLeg.zRot = 0.0F;
+
+        if (this.riding) {
+            this.rightArm.xRot += (-(float) Math.PI / 5F);
+            this.leftArm.xRot += (-(float) Math.PI / 5F);
+            this.rightLeg.xRot = -1.4137167F;
+            this.rightLeg.yRot = ((float) Math.PI / 10F);
+            this.rightLeg.zRot = 0.07853982F;
+            this.leftLeg.xRot = -1.4137167F;
+            this.leftLeg.yRot = (-(float) Math.PI / 10F);
+            this.leftLeg.zRot = -0.07853982F;
+        }
+
+        this.rightArm.yRot = 0.0F;
+        this.leftArm.yRot = 0.0F;
+        boolean flag2 = player.getMainArm() == HumanoidArm.RIGHT;
+        boolean flag3 = flag2 ? this.leftArmPose.isTwoHanded() : this.rightArmPose.isTwoHanded();
+
+        if (flag2 != flag3) {
+            this.poseLeftArm(player);
+            this.poseRightArm(player);
+        } else {
+            this.poseRightArm(player);
+            this.poseLeftArm(player);
+        }
+
+        this.setupAttackAnimation(player, ageInTicks);
+
+        if (this.crouching) {
+            this.body.xRot = 0.5F;
+            this.rightArm.xRot += 0.4F;
+            this.leftArm.xRot += 0.4F;
+            this.rightLeg.z = 0.5F;
+            this.leftLeg.z = 0.5F;
+            this.rightLeg.y = 8.45F;
+            this.leftLeg.y = 8.45F;
+            this.head.y = -2.8F;
+            this.head.z = -5.0F;
+            this.body.y = 11.2F;
+            this.leftArm.y = -1.1F;
+            this.rightArm.y = -1.1F;
+            this.leftArm.z = -5.75F;
+            this.rightArm.z = -5.75F;
+        }
+
+        AnimationUtils.bobArms(this.rightArm, this.leftArm, ageInTicks);
+
+        if (this.swimAmount > 0.0F) {
+            float f1 = limbSwing % 26.0F;
+            HumanoidArm handside = this.getSwingingArm(player);
+            float f2 = handside == HumanoidArm.RIGHT && this.attackTime > 0.0F ? 0.0F : this.swimAmount;
+            float f3 = handside == HumanoidArm.LEFT && this.attackTime > 0.0F ? 0.0F : this.swimAmount;
+
+            if (f1 < 14.0F) {
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, 0.0F);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, 0.0F);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, (float) Math.PI + 1.8707964F * this.quadraticArmUpdate(f1) / this.quadraticArmUpdate(14.0F));
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, (float) Math.PI - 1.8707964F * this.quadraticArmUpdate(f1) / this.quadraticArmUpdate(14.0F));
+            } else if (f1 >= 14.0F && f1 < 22.0F) {
+                float f6 = (f1 - 14.0F) / 8.0F;
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, ((float) Math.PI / 2F) * f6);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, ((float) Math.PI / 2F) * f6);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, 5.012389F - 1.8707964F * f6);
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, 1.2707963F + 1.8707964F * f6);
+            } else if (f1 >= 22.0F && f1 < 26.0F) {
+                float f4 = (f1 - 22.0F) / 4.0F;
+                this.leftArm.xRot = this.rotlerpRad(f3, this.leftArm.xRot, ((float) Math.PI / 2F) - ((float) Math.PI / 2F) * f4);
+                this.rightArm.xRot = Mth.lerp(f2, this.rightArm.xRot, ((float) Math.PI / 2F) - ((float) Math.PI / 2F) * f4);
+                this.leftArm.yRot = this.rotlerpRad(f3, this.leftArm.yRot, (float) Math.PI);
+                this.rightArm.yRot = Mth.lerp(f2, this.rightArm.yRot, (float) Math.PI);
+                this.leftArm.zRot = this.rotlerpRad(f3, this.leftArm.zRot, (float) Math.PI);
+                this.rightArm.zRot = Mth.lerp(f2, this.rightArm.zRot, (float) Math.PI);
+            }
+
+            this.leftLeg.xRot = Mth.lerp(this.swimAmount, this.leftLeg.xRot, 0.3F * Mth.cos(limbSwing * 0.33333334F + (float) Math.PI));
+            this.rightLeg.xRot = Mth.lerp(this.swimAmount, this.rightLeg.xRot, 0.3F * Mth.cos(limbSwing * 0.33333334F));
+        }
+
+        this.hat.copyFrom(this.head);
+    }
+
+    private float quadraticArmUpdate(float f) {
+        return -65.0F * f + f * f;
+    }
+
+    private HumanoidArm getSwingingArm(AbstractClientPlayer player) {
+        HumanoidArm humanoidarm = player.getMainArm();
+        return player.swingingArm == InteractionHand.MAIN_HAND ? humanoidarm : humanoidarm.getOpposite();
+    }
+
+    private void poseLeftArm(AbstractClientPlayer player) {
+        switch (this.leftArmPose) {
+            case EMPTY:
+                this.leftArm.yRot = 0.0F;
+                break;
+            case BLOCK:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - 0.9424779F;
+                this.leftArm.yRot = ((float) Math.PI / 6F);
+                break;
+            case ITEM:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - ((float) Math.PI / 10F);
+                this.leftArm.yRot = 0.0F;
+                break;
+            case THROW_SPEAR:
+                this.leftArm.xRot = this.leftArm.xRot * 0.5F - (float) Math.PI;
+                this.leftArm.yRot = 0.0F;
+                break;
+            case BOW_AND_ARROW:
+                this.rightArm.yRot = -0.1F + this.head.yRot - 0.4F;
+                this.leftArm.yRot = 0.1F + this.head.yRot;
+                this.rightArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                this.leftArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                break;
+            case CROSSBOW_CHARGE:
+                AnimationUtils.animateCrossbowCharge(this.rightArm, this.leftArm, player, false);
+                break;
+            case CROSSBOW_HOLD:
+                AnimationUtils.animateCrossbowHold(this.rightArm, this.leftArm, this.head, false);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void poseRightArm(AbstractClientPlayer player) {
+        switch (this.rightArmPose) {
+            case EMPTY:
+                this.rightArm.yRot = 0.0F;
+                break;
+            case BLOCK:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - 0.9424779F;
+                this.rightArm.yRot = (-(float) Math.PI / 6F);
+                break;
+            case ITEM:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - ((float) Math.PI / 10F);
+                this.rightArm.yRot = 0.0F;
+                break;
+            case THROW_SPEAR:
+                this.rightArm.xRot = this.rightArm.xRot * 0.5F - (float) Math.PI;
+                this.rightArm.yRot = 0.0F;
+                break;
+            case BOW_AND_ARROW:
+                this.rightArm.yRot = -0.1F + this.head.yRot;
+                this.leftArm.yRot = 0.1F + this.head.yRot + 0.4F;
+                this.rightArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                this.leftArm.xRot = (-(float) Math.PI / 2F) + this.head.xRot;
+                break;
+            case CROSSBOW_CHARGE:
+                AnimationUtils.animateCrossbowCharge(this.rightArm, this.leftArm, player, true);
+                break;
+            case CROSSBOW_HOLD:
+                AnimationUtils.animateCrossbowHold(this.rightArm, this.leftArm, this.head, true);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    protected Iterable<ModelPart> bodyParts() {
+        return ImmutableList.of(this.body, this.rightArm, this.leftArm, this.rightLeg, this.leftLeg);
+    }
+
+    @Override
+    public void renderFirstPersonHand(PoseStack poseStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, ModelPart hand, ModelPart handOverlay,
+            ResourceLocation texture) {
+        hand.xRot = 0;
+        hand.x = 0.0F;
+        hand.y = 2.0F;
+        hand.z = 3.0F;
+        hand.render(poseStack, buffer.getBuffer(RenderType.entityTranslucent(texture)), packedLight, OverlayTexture.NO_OVERLAY);
+        handOverlay.xRot = 0;
+        handOverlay.y = 1.5F;
+        handOverlay.render(poseStack, buffer.getBuffer(RenderType.entityTranslucent(texture)), packedLight, OverlayTexture.NO_OVERLAY);
+    }
+}

--- a/src/main/java/com/superworldsun/superslegend/interfaces/IHandRenderer.java
+++ b/src/main/java/com/superworldsun/superslegend/interfaces/IHandRenderer.java
@@ -1,0 +1,15 @@
+package com.superworldsun.superslegend.interfaces;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(value = Dist.CLIENT)
+public interface IHandRenderer {
+    void renderFirstPersonHand(PoseStack poseStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, ModelPart hand, ModelPart handOverlay,
+            ResourceLocation texture);
+}

--- a/src/main/java/com/superworldsun/superslegend/interfaces/IPlayerModelChanger.java
+++ b/src/main/java/com/superworldsun/superslegend/interfaces/IPlayerModelChanger.java
@@ -1,0 +1,46 @@
+package com.superworldsun.superslegend.interfaces;
+
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import top.theillusivec4.curios.api.CuriosApi;
+
+import java.util.Optional;
+
+public interface IPlayerModelChanger {
+    @OnlyIn(value = Dist.CLIENT)
+    PlayerModel<AbstractClientPlayer> getPlayerModel(AbstractClientPlayer player);
+
+    @OnlyIn(value = Dist.CLIENT)
+    ResourceLocation getPlayerTexture(AbstractClientPlayer player);
+
+    /**
+     * Returns the model changer from the player's equipped armor or curios, or null if there is none.
+     */
+    static IPlayerModelChanger get(Player player) {
+        for (ItemStack stack : player.getArmorSlots()) {
+            if (stack.getItem() instanceof IPlayerModelChanger changer) {
+                return changer;
+            }
+        }
+
+        Optional<IItemHandlerModifiable> curios = CuriosApi.getCuriosHelper().getEquippedCurios(player).resolve();
+
+        if (curios.isPresent()) {
+            for (int i = 0; i < curios.get().getSlots(); i++) {
+                ItemStack stack = curios.get().getStackInSlot(i);
+
+                if (!stack.isEmpty() && stack.getItem() instanceof IPlayerModelChanger changer) {
+                    return changer;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/superworldsun/superslegend/items/curios/head/masks/DekuMask.java
+++ b/src/main/java/com/superworldsun/superslegend/items/curios/head/masks/DekuMask.java
@@ -1,7 +1,12 @@
 package com.superworldsun.superslegend.items.curios.head.masks;
 
 import com.superworldsun.superslegend.SupersLegendMain;
+import com.superworldsun.superslegend.client.model.player.PlayerTransformationModels;
+import com.superworldsun.superslegend.interfaces.IPlayerModelChanger;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -17,9 +22,23 @@ import java.util.List;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, modid = SupersLegendMain.MOD_ID)
 
-public class DekuMask extends Item implements ICurioItem {
+public class DekuMask extends Item implements ICurioItem, IPlayerModelChanger {
+    private static final ResourceLocation PLAYER_TEXTURE = new ResourceLocation(SupersLegendMain.MOD_ID, "textures/entity/deku_player.png");
+
     public DekuMask(Properties pProperties) {
         super(pProperties);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public PlayerModel<AbstractClientPlayer> getPlayerModel(AbstractClientPlayer player) {
+        return PlayerTransformationModels.getDeku();
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public ResourceLocation getPlayerTexture(AbstractClientPlayer player) {
+        return PLAYER_TEXTURE;
     }
 
     /*@SubscribeEvent

--- a/src/main/java/com/superworldsun/superslegend/items/curios/head/masks/GoronMask.java
+++ b/src/main/java/com/superworldsun/superslegend/items/curios/head/masks/GoronMask.java
@@ -1,8 +1,13 @@
 package com.superworldsun.superslegend.items.curios.head.masks;
 
 import com.superworldsun.superslegend.SupersLegendMain;
+import com.superworldsun.superslegend.client.model.player.PlayerTransformationModels;
+import com.superworldsun.superslegend.interfaces.IPlayerModelChanger;
 import com.superworldsun.superslegend.interfaces.JumpingEntity;
 import com.superworldsun.superslegend.registries.ItemInit;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
@@ -32,11 +37,24 @@ import java.util.List;
 import java.util.UUID;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, modid = SupersLegendMain.MOD_ID)
-public class GoronMask extends Item implements ICurioItem {
+public class GoronMask extends Item implements ICurioItem, IPlayerModelChanger {
     private static final UUID GORON_WATER_MODIFIER_ID = UUID.fromString("9198efe1-249e-4dc9-825b-e79aa2d3e2cf");
+    private static final ResourceLocation PLAYER_TEXTURE = new ResourceLocation(SupersLegendMain.MOD_ID, "textures/entity/goron_player.png");
 
     public GoronMask(Properties pProperties) {
         super(pProperties);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public PlayerModel<AbstractClientPlayer> getPlayerModel(AbstractClientPlayer player) {
+        return PlayerTransformationModels.getGoron();
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public ResourceLocation getPlayerTexture(AbstractClientPlayer player) {
+        return PLAYER_TEXTURE;
     }
 
     //TODO, dosent work, should it slower loosing air

--- a/src/main/java/com/superworldsun/superslegend/items/curios/head/masks/ZoraMask.java
+++ b/src/main/java/com/superworldsun/superslegend/items/curios/head/masks/ZoraMask.java
@@ -3,7 +3,12 @@ package com.superworldsun.superslegend.items.curios.head.masks;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.superworldsun.superslegend.SupersLegendMain;
+import com.superworldsun.superslegend.client.model.player.PlayerTransformationModels;
+import com.superworldsun.superslegend.interfaces.IPlayerModelChanger;
 import com.superworldsun.superslegend.registries.ItemInit;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -33,13 +38,26 @@ import java.util.List;
 import java.util.UUID;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, modid = SupersLegendMain.MOD_ID)
-public class ZoraMask extends Item implements ICurioItem
+public class ZoraMask extends Item implements ICurioItem, IPlayerModelChanger
 {
     private static final UUID ZORA_WATER_MODIFIER_ID = UUID.fromString("734af1f7-e76b-47f0-ba52-5a1a12a9edd2");
+    private static final ResourceLocation PLAYER_TEXTURE = new ResourceLocation(SupersLegendMain.MOD_ID, "textures/entity/zora_player.png");
     float manaCost = 0.03F;
 
     public ZoraMask(Properties pProperties) {
         super(pProperties);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public PlayerModel<AbstractClientPlayer> getPlayerModel(AbstractClientPlayer player) {
+        return PlayerTransformationModels.getZora();
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    @Override
+    public ResourceLocation getPlayerTexture(AbstractClientPlayer player) {
+        return PLAYER_TEXTURE;
     }
 
     @Override

--- a/src/main/java/com/superworldsun/superslegend/mixin/client/MixinPlayerRenderer.java
+++ b/src/main/java/com/superworldsun/superslegend/mixin/client/MixinPlayerRenderer.java
@@ -1,0 +1,70 @@
+package com.superworldsun.superslegend.mixin.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.superworldsun.superslegend.interfaces.IPlayerModelChanger;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.client.renderer.entity.player.PlayerRenderer;
+import net.minecraft.client.renderer.entity.layers.CapeLayer;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerRenderer.class)
+public abstract class MixinPlayerRenderer extends LivingEntityRenderer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> {
+    @Unique
+    private PlayerModel<AbstractClientPlayer> superslegend$baseModel;
+    @Unique
+    private RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> superslegend$armorLayer;
+    @Unique
+    private RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> superslegend$capeLayer;
+
+    // This constructor is fake and never used
+    protected MixinPlayerRenderer() {
+        super(null, null, 0);
+    }
+
+    @Inject(method = "render(Lnet/minecraft/client/player/AbstractClientPlayer;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", at = @At("HEAD"))
+    private void superslegend$chooseCurrentModel(AbstractClientPlayer player, float rotationYaw, float partialTicks, PoseStack poseStack, MultiBufferSource buffer, int light, CallbackInfo ci) {
+        if (superslegend$baseModel == null) {
+            superslegend$baseModel = model;
+
+            for (RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> layer : layers) {
+                if (layer instanceof HumanoidArmorLayer) {
+                    superslegend$armorLayer = layer;
+                } else if (layer instanceof CapeLayer) {
+                    superslegend$capeLayer = layer;
+                }
+            }
+        }
+
+        IPlayerModelChanger changer = IPlayerModelChanger.get(player);
+        model = changer != null ? changer.getPlayerModel(player) : superslegend$baseModel;
+
+        // Armor and cape do not fit the transformed models
+        if (model != superslegend$baseModel) {
+            layers.remove(superslegend$armorLayer);
+            layers.remove(superslegend$capeLayer);
+        } else if (!layers.contains(superslegend$armorLayer)) {
+            layers.add(superslegend$armorLayer);
+            layers.add(superslegend$capeLayer);
+        }
+    }
+
+    @Inject(method = "getTextureLocation(Lnet/minecraft/client/player/AbstractClientPlayer;)Lnet/minecraft/resources/ResourceLocation;", at = @At("HEAD"), cancellable = true)
+    private void superslegend$getTextureLocation(AbstractClientPlayer player, CallbackInfoReturnable<ResourceLocation> ci) {
+        IPlayerModelChanger changer = IPlayerModelChanger.get(player);
+
+        if (changer != null) {
+            ci.setReturnValue(changer.getPlayerTexture(player));
+        }
+    }
+}

--- a/src/main/resources/superslegend.mixins.json
+++ b/src/main/resources/superslegend.mixins.json
@@ -8,5 +8,8 @@
     "MixinAbstractSkeletonEntity",
     "MixinFlowingFluid"
   ],
+  "client": [
+    "client.MixinPlayerRenderer"
+  ],
   "minVersion": "0.8"
 }


### PR DESCRIPTION
ports the mask transformations from 1.16.5: the three models are converted to the LayerDefinition system, model/texture swapping is done via a PlayerRenderer mixin (as before), and first-person hands now use Forge's RenderArmEvent instead of an @Overwrite. 

Not included: Goron 1.52 scaling (I suggest using Pehkui which is already a dependency)